### PR TITLE
feat: Add storage location type selection (local/network/cloud)

### DIFF
--- a/docs/plans/2026-01-31-storage-location-types-design.md
+++ b/docs/plans/2026-01-31-storage-location-types-design.md
@@ -1,0 +1,661 @@
+# Storage Location Types Design
+
+**Date:** 2026-01-31
+**Issue:** #76
+**Status:** Draft
+
+## Summary
+
+Extend the storage location system to support multiple storage types beyond local filesystem:
+- **Local** - Folders on the local machine
+- **Network** - SMB and NFS shares with direct protocol access
+- **Cloud** - S3-compatible, Google Drive, OneDrive, Dropbox, Azure Blob, Google Cloud Storage
+
+## Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Network approach | Direct protocol (app connects with credentials) |
+| Cloud providers | All major: S3, GDrive, OneDrive, Dropbox, Azure, GCS |
+| Credential storage | Encrypted in SQLite, master key in OS keychain |
+| OAuth flow | Local redirect server on localhost |
+| Backend architecture | Adapter pattern with abstract interface |
+| Connection validation | Test on save + validate on access |
+
+## Storage Types & Configuration
+
+### Type/Subtype Schema
+
+| Type | Subtype | Config Fields |
+|------|---------|---------------|
+| `local` | - | `path` |
+| `network` | `smb` | `server`, `share`, `username`, `password`*, `domain` |
+| `network` | `nfs` | `server`, `export_path`, `mount_options` |
+| `cloud` | `s3` | `bucket`, `region`, `access_key`, `secret_key`*, `endpoint` |
+| `cloud` | `azure` | `container`, `account_name`, `account_key`* |
+| `cloud` | `gcs` | `bucket`, `project_id`, `credentials_json`* |
+| `cloud` | `gdrive` | `folder_id`, `oauth_tokens`* |
+| `cloud` | `onedrive` | `folder_path`, `oauth_tokens`* |
+| `cloud` | `dropbox` | `folder_path`, `oauth_tokens`* |
+
+*Fields marked with * are encrypted at rest.
+
+### Database Migration
+
+Add `subtype` column to `storage_locations` table:
+
+```sql
+ALTER TABLE storage_locations ADD COLUMN subtype VARCHAR(50);
+UPDATE storage_locations SET subtype = NULL WHERE type = 'local';
+```
+
+## Backend Architecture
+
+### Storage Adapter Interface
+
+```python
+# packages/backend/storage/base.py
+from typing import Protocol
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class FileInfo:
+    name: str
+    path: str
+    size: int
+    is_directory: bool
+    modified_at: datetime
+    mime_type: str | None = None
+
+class StorageAdapter(Protocol):
+    """Abstract interface for all storage backends."""
+
+    async def test_connection(self) -> bool:
+        """Verify connectivity and credentials. Raises on failure."""
+        ...
+
+    async def list_files(self, path: str = "") -> list[FileInfo]:
+        """List files and directories at path."""
+        ...
+
+    async def read_file(self, path: str) -> bytes:
+        """Read file contents."""
+        ...
+
+    async def write_file(self, path: str, data: bytes) -> None:
+        """Write data to file, creating parent directories as needed."""
+        ...
+
+    async def delete_file(self, path: str) -> None:
+        """Delete a file."""
+        ...
+
+    async def exists(self, path: str) -> bool:
+        """Check if file or directory exists."""
+        ...
+
+    async def get_file_info(self, path: str) -> FileInfo:
+        """Get metadata for a single file."""
+        ...
+
+    async def ensure_directory(self, path: str) -> None:
+        """Create directory and parents if they don't exist."""
+        ...
+```
+
+### Adapter Implementations
+
+| Adapter | Library | Notes |
+|---------|---------|-------|
+| `LocalAdapter` | `aiofiles` | Async file I/O |
+| `SMBAdapter` | `smbprotocol` | Pure Python SMB2/3 |
+| `NFSAdapter` | `libnfs` | Python bindings or subprocess mount |
+| `S3Adapter` | `aioboto3` | Works with all S3-compatible services |
+| `AzureAdapter` | `azure-storage-blob` | Azure Blob Storage |
+| `GCSAdapter` | `google-cloud-storage` | Google Cloud Storage |
+| `GDriveAdapter` | `google-api-python-client` | Google Drive API |
+| `OneDriveAdapter` | `httpx` | Microsoft Graph API |
+| `DropboxAdapter` | `dropbox` | Official Dropbox SDK |
+
+### Factory Function
+
+```python
+# packages/backend/storage/factory.py
+from persistence.models import StorageLocation
+from storage.base import StorageAdapter
+from storage.adapters import (
+    LocalAdapter, SMBAdapter, NFSAdapter, S3Adapter,
+    AzureAdapter, GCSAdapter, GDriveAdapter, OneDriveAdapter, DropboxAdapter
+)
+from services.encryption import decrypt_config
+
+ADAPTERS = {
+    ("local", None): LocalAdapter,
+    ("network", "smb"): SMBAdapter,
+    ("network", "nfs"): NFSAdapter,
+    ("cloud", "s3"): S3Adapter,
+    ("cloud", "azure"): AzureAdapter,
+    ("cloud", "gcs"): GCSAdapter,
+    ("cloud", "gdrive"): GDriveAdapter,
+    ("cloud", "onedrive"): OneDriveAdapter,
+    ("cloud", "dropbox"): DropboxAdapter,
+}
+
+def get_adapter(location: StorageLocation) -> StorageAdapter:
+    """Get appropriate adapter for a storage location."""
+    adapter_class = ADAPTERS.get((location.type, location.subtype))
+    if not adapter_class:
+        raise ValueError(f"Unknown storage type: {location.type}/{location.subtype}")
+
+    config = decrypt_config(location.config)
+    return adapter_class(config)
+```
+
+## Credential Encryption
+
+### Master Key Management
+
+```python
+# packages/backend/services/encryption.py
+import keyring
+import secrets
+from cryptography.fernet import Fernet
+import base64
+import json
+import os
+
+SERVICE_NAME = "verbatim-studio"
+KEY_NAME = "master-key"
+FALLBACK_PATH = os.path.expanduser("~/.verbatim-studio/.keyfile")
+
+def get_master_key() -> bytes:
+    """Get or create master encryption key."""
+    # Try OS keychain first
+    try:
+        key = keyring.get_password(SERVICE_NAME, KEY_NAME)
+        if key:
+            return base64.b64decode(key)
+    except Exception:
+        pass  # Keyring unavailable
+
+    # Try fallback file
+    if os.path.exists(FALLBACK_PATH):
+        with open(FALLBACK_PATH, "rb") as f:
+            return f.read()
+
+    # Generate new key
+    new_key = Fernet.generate_key()
+
+    # Try to store in keychain
+    try:
+        keyring.set_password(SERVICE_NAME, KEY_NAME, base64.b64encode(new_key).decode())
+        return new_key
+    except Exception:
+        pass
+
+    # Fall back to file
+    os.makedirs(os.path.dirname(FALLBACK_PATH), exist_ok=True)
+    with open(FALLBACK_PATH, "wb") as f:
+        f.write(new_key)
+    os.chmod(FALLBACK_PATH, 0o600)
+    return new_key
+
+def get_fernet() -> Fernet:
+    return Fernet(get_master_key())
+
+SENSITIVE_FIELDS = {
+    "password", "secret_key", "account_key", "connection_string",
+    "credentials_json", "oauth_tokens", "access_token", "refresh_token"
+}
+
+def encrypt_config(config: dict) -> dict:
+    """Encrypt sensitive fields in config."""
+    fernet = get_fernet()
+    result = {}
+    for key, value in config.items():
+        if key in SENSITIVE_FIELDS and value:
+            encrypted = fernet.encrypt(json.dumps(value).encode())
+            result[key] = {"_encrypted": base64.b64encode(encrypted).decode()}
+        else:
+            result[key] = value
+    return result
+
+def decrypt_config(config: dict) -> dict:
+    """Decrypt sensitive fields in config."""
+    fernet = get_fernet()
+    result = {}
+    for key, value in config.items():
+        if isinstance(value, dict) and "_encrypted" in value:
+            decrypted = fernet.decrypt(base64.b64decode(value["_encrypted"]))
+            result[key] = json.loads(decrypted.decode())
+        else:
+            result[key] = value
+    return result
+```
+
+## OAuth Flow
+
+### Supported Providers
+
+| Provider | Auth URL | Scopes |
+|----------|----------|--------|
+| Google Drive | `accounts.google.com/o/oauth2/v2/auth` | `drive.file` |
+| OneDrive | `login.microsoftonline.com/.../oauth2/v2.0/authorize` | `Files.ReadWrite` |
+| Dropbox | `www.dropbox.com/oauth2/authorize` | `files.content.write` |
+
+### OAuth Endpoints
+
+```
+POST /api/storage-locations/oauth/start
+  Body: { "provider": "gdrive" }
+  Returns: { "auth_url": "https://...", "state": "abc123" }
+
+GET /api/storage-locations/oauth/status/{state}
+  Returns: { "status": "pending" | "complete" | "error", "location_id": "..." }
+```
+
+### Callback Server
+
+```python
+# packages/backend/services/oauth.py
+import asyncio
+from aiohttp import web
+import secrets
+from datetime import datetime, timedelta
+
+# In-memory state store (TTL 5 minutes)
+oauth_states: dict[str, dict] = {}
+
+PORTS = [9876, 9877, 9878, 9879]
+
+async def start_oauth(provider: str) -> tuple[str, str]:
+    """Start OAuth flow, return (auth_url, state)."""
+    state = secrets.token_urlsafe(32)
+    oauth_states[state] = {
+        "provider": provider,
+        "status": "pending",
+        "created_at": datetime.utcnow(),
+    }
+
+    # Start callback server
+    port = await start_callback_server(state)
+    redirect_uri = f"http://localhost:{port}/callback"
+
+    # Build auth URL based on provider
+    auth_url = build_auth_url(provider, state, redirect_uri)
+
+    return auth_url, state
+
+async def start_callback_server(state: str) -> int:
+    """Start temp HTTP server for OAuth callback."""
+    app = web.Application()
+    app.router.add_get("/callback", lambda r: handle_callback(r, state))
+
+    for port in PORTS:
+        try:
+            runner = web.AppRunner(app)
+            await runner.setup()
+            site = web.TCPSite(runner, "localhost", port)
+            await site.start()
+
+            # Store runner for cleanup
+            oauth_states[state]["runner"] = runner
+            oauth_states[state]["port"] = port
+            return port
+        except OSError:
+            continue
+
+    raise RuntimeError("No available ports for OAuth callback")
+
+async def handle_callback(request: web.Request, expected_state: str) -> web.Response:
+    """Handle OAuth callback from provider."""
+    state = request.query.get("state")
+    code = request.query.get("code")
+    error = request.query.get("error")
+
+    if state != expected_state:
+        return web.Response(text="Invalid state", status=400)
+
+    if error:
+        oauth_states[state]["status"] = "error"
+        oauth_states[state]["error"] = error
+        return web.Response(text=f"Authorization failed: {error}")
+
+    # Exchange code for tokens
+    provider = oauth_states[state]["provider"]
+    tokens = await exchange_code(provider, code, oauth_states[state]["port"])
+
+    # Create storage location with encrypted tokens
+    location_id = await create_oauth_location(provider, tokens)
+
+    oauth_states[state]["status"] = "complete"
+    oauth_states[state]["location_id"] = location_id
+
+    # Cleanup server after short delay
+    asyncio.create_task(cleanup_oauth_server(state))
+
+    return web.Response(
+        text="<html><body><h1>Success!</h1><p>You can close this window.</p></body></html>",
+        content_type="text/html"
+    )
+
+async def cleanup_oauth_server(state: str):
+    """Shutdown callback server after delay."""
+    await asyncio.sleep(2)
+    if state in oauth_states and "runner" in oauth_states[state]:
+        await oauth_states[state]["runner"].cleanup()
+```
+
+### Token Refresh
+
+```python
+# In each OAuth adapter
+async def ensure_valid_token(self) -> str:
+    """Refresh token if expired, return valid access token."""
+    if self.token_expires_at > datetime.utcnow() + timedelta(minutes=5):
+        return self.access_token
+
+    # Refresh the token
+    new_tokens = await self.refresh_token()
+
+    # Update stored tokens (encrypted)
+    await self.update_stored_tokens(new_tokens)
+
+    return new_tokens["access_token"]
+```
+
+## Frontend UI
+
+### Component Structure
+
+```
+packages/frontend/src/components/storage/
+├── StorageLocationModal.tsx      # Main modal container
+├── StorageTypeSelector.tsx       # Step 1: Local/Network/Cloud cards
+├── StorageSubtypeSelector.tsx    # Step 2: SMB/NFS or cloud provider
+├── StorageConfigForm.tsx         # Step 3: Dynamic form fields
+├── StorageTestButton.tsx         # Test connection with status
+├── StorageLocationCard.tsx       # List item with status indicator
+└── OAuthConnectButton.tsx        # "Connect with Google" style button
+```
+
+### Add Location Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Add Storage Location                              [X]      │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  Step 1: Choose storage type                                │
+│                                                             │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐           │
+│  │     📁      │ │     🌐      │ │     ☁️      │           │
+│  │   Local     │ │   Network   │ │    Cloud    │           │
+│  │  Storage    │ │   Storage   │ │   Storage   │           │
+│  │             │ │             │ │             │           │
+│  │ Folder on   │ │ SMB or NFS  │ │ S3, Google  │           │
+│  │ this device │ │ share       │ │ Drive, etc  │           │
+│  └─────────────┘ └─────────────┘ └─────────────┘           │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Type-Specific Forms
+
+**Local:**
+```
+Name: [____________________]
+Path: [____________________] [Browse]
+```
+
+**SMB:**
+```
+Name:     [____________________]
+Server:   [____________________]  (e.g., 192.168.1.100)
+Share:    [____________________]  (e.g., media)
+Username: [____________________]
+Password: [____________________]
+Domain:   [____________________]  (optional)
+```
+
+**S3:**
+```
+Name:       [____________________]
+Bucket:     [____________________]
+Region:     [____________________]
+Access Key: [____________________]
+Secret Key: [____________________]
+Endpoint:   [____________________]  (optional, for non-AWS)
+```
+
+**OAuth Providers:**
+```
+Name:   [____________________]
+Folder: [____________________]  (optional, default: root)
+
+        [ 🔗 Connect with Google ]
+```
+
+### Location List Card
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ 🟢 My NAS                                    [Edit] [Delete]│
+│    SMB · //192.168.1.100/media                             │
+│    Default location                                        │
+├────────────────────────────────────────────────────────────┤
+│ 🟡 Backblaze B2                              [Edit] [Delete]│
+│    S3 · verbatim-backups                                   │
+│    Last checked: 2 min ago (slow response)                 │
+├────────────────────────────────────────────────────────────┤
+│ 🔴 Google Drive                        [Reauthorize] [Delete]│
+│    OAuth token expired                                     │
+└────────────────────────────────────────────────────────────┘
+```
+
+## Error Handling
+
+### Connection States
+
+| State | Icon | Meaning |
+|-------|------|---------|
+| `healthy` | 🟢 | Last access succeeded |
+| `degraded` | 🟡 | Slow or intermittent |
+| `unreachable` | 🔴 | Connection failed |
+| `auth_expired` | 🔴 | OAuth token needs refresh |
+
+### Retry Logic
+
+```python
+# In base adapter or decorator
+MAX_RETRIES = 3
+BACKOFF_SECONDS = [1, 2, 4]
+
+async def with_retry(operation):
+    for attempt in range(MAX_RETRIES):
+        try:
+            return await operation()
+        except (ConnectionError, TimeoutError) as e:
+            if attempt == MAX_RETRIES - 1:
+                raise StorageUnavailableError(str(e))
+            await asyncio.sleep(BACKOFF_SECONDS[attempt])
+```
+
+### Error Types
+
+```python
+class StorageError(Exception):
+    """Base storage error."""
+    pass
+
+class StorageUnavailableError(StorageError):
+    """Storage location is unreachable."""
+    pass
+
+class StorageAuthError(StorageError):
+    """Authentication failed or expired."""
+    pass
+
+class StorageNotFoundError(StorageError):
+    """File or directory not found."""
+    pass
+
+class StoragePermissionError(StorageError):
+    """Permission denied."""
+    pass
+```
+
+## Background Health Checks
+
+```python
+# packages/backend/services/storage_health.py
+import asyncio
+from datetime import datetime, timedelta
+
+CHECK_INTERVAL = 15 * 60  # 15 minutes
+
+async def health_check_loop():
+    """Periodically check non-local storage locations."""
+    while True:
+        await asyncio.sleep(CHECK_INTERVAL)
+
+        locations = await get_non_local_locations()
+        for location in locations:
+            try:
+                adapter = get_adapter(location)
+                await asyncio.wait_for(adapter.test_connection(), timeout=30)
+                await update_location_status(location.id, "healthy")
+            except asyncio.TimeoutError:
+                await update_location_status(location.id, "degraded")
+            except StorageAuthError:
+                await update_location_status(location.id, "auth_expired")
+            except Exception:
+                await update_location_status(location.id, "unreachable")
+```
+
+## API Endpoints
+
+### New Endpoints
+
+```
+POST   /api/storage-locations/test
+       Body: { type, subtype, config }
+       Returns: { success: bool, error?: string, latency_ms?: number }
+
+POST   /api/storage-locations/oauth/start
+       Body: { provider: "gdrive" | "onedrive" | "dropbox" }
+       Returns: { auth_url: string, state: string }
+
+GET    /api/storage-locations/oauth/status/{state}
+       Returns: { status: "pending" | "complete" | "error", location_id?: string }
+
+POST   /api/storage-locations/{id}/reauthorize
+       Returns: { auth_url: string, state: string }
+```
+
+### Updated Endpoints
+
+```
+POST   /api/storage-locations
+       Body: { name, type, subtype, config, is_default }
+       (config is encrypted before storage)
+
+PUT    /api/storage-locations/{id}
+       Body: { name?, config?, is_default? }
+       (config is encrypted before storage)
+
+GET    /api/storage-locations
+       Returns: { items: [...], status: { id: "healthy" | "degraded" | ... } }
+```
+
+## Dependencies
+
+### New Python Packages
+
+```
+# requirements.txt additions
+smbprotocol>=1.13.0      # SMB2/3 client
+aioboto3>=12.0.0         # Async S3 client
+azure-storage-blob>=12.0 # Azure Blob Storage
+google-cloud-storage>=2.0 # Google Cloud Storage
+google-api-python-client>=2.0 # Google Drive API
+dropbox>=11.0            # Dropbox SDK
+keyring>=25.0            # OS keychain access
+cryptography>=42.0       # Fernet encryption
+aiohttp>=3.9             # OAuth callback server
+```
+
+### Optional (NFS)
+
+```
+libnfs-python>=1.0       # NFS client (may require system lib)
+```
+
+## Implementation Phases
+
+### Phase 1: Foundation (Base Infrastructure)
+- [ ] Database migration: add `subtype` column
+- [ ] Create `storage/base.py` with `StorageAdapter` protocol
+- [ ] Create `services/encryption.py` with keyring + Fernet
+- [ ] Create `storage/factory.py` with adapter factory
+- [ ] Refactor existing code to use `LocalAdapter`
+- [ ] Update frontend with type selector UI (local only functional)
+- [ ] Add `POST /api/storage-locations/test` endpoint
+
+### Phase 2: Network Storage (SMB/NFS)
+- [ ] Implement `SMBAdapter` using `smbprotocol`
+- [ ] Implement `NFSAdapter` using `libnfs` or mount
+- [ ] Add frontend forms for SMB and NFS
+- [ ] Test connection validation for network types
+
+### Phase 3: S3-Compatible Cloud
+- [ ] Implement `S3Adapter` using `aioboto3`
+- [ ] Add frontend form for S3 configuration
+- [ ] Support custom endpoints for B2, Wasabi, MinIO, etc.
+- [ ] Test with AWS S3 and Backblaze B2
+
+### Phase 4: OAuth Cloud Providers
+- [ ] Implement OAuth callback server
+- [ ] Implement `GDriveAdapter` with token refresh
+- [ ] Implement `OneDriveAdapter` with Microsoft Graph
+- [ ] Implement `DropboxAdapter`
+- [ ] Add frontend OAuth connect buttons
+- [ ] Add reauthorization flow for expired tokens
+
+### Phase 5: Azure & GCS
+- [ ] Implement `AzureAdapter`
+- [ ] Implement `GCSAdapter`
+- [ ] Add frontend forms for service credentials
+
+### Phase 6: Polish
+- [ ] Add background health check loop
+- [ ] Add status indicators to location list
+- [ ] Handle and display connection errors gracefully
+- [ ] Add "Reauthorize" button for OAuth locations
+- [ ] Write user documentation for each storage type
+
+## Testing Strategy
+
+### Unit Tests
+- Encryption/decryption round-trip
+- Config validation for each type
+- Adapter factory routing
+
+### Integration Tests
+- Local adapter with temp directories
+- S3 adapter with LocalStack or MinIO
+- OAuth flow with mock provider
+
+### Manual Testing
+- Real SMB share on local network
+- Real S3 bucket
+- Real Google Drive OAuth flow
+
+## Security Considerations
+
+1. **Credentials never logged** - Ensure sensitive fields are masked in logs
+2. **HTTPS for OAuth** - All OAuth redirects use HTTPS (except localhost callback)
+3. **Token expiry** - Refresh tokens before they expire
+4. **Keyring fallback** - Warn users if using file-based key storage
+5. **Input validation** - Sanitize paths to prevent directory traversal

--- a/docs/plans/2026-01-31-storage-location-types-implementation.md
+++ b/docs/plans/2026-01-31-storage-location-types-implementation.md
@@ -1,0 +1,1981 @@
+# Storage Location Types Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add support for multiple storage backends: Local, Network (SMB/NFS), and Cloud (S3, Google Drive, OneDrive, Dropbox, Azure Blob, GCS).
+
+**Architecture:** Adapter pattern with abstract `StorageAdapter` interface. Each storage type has its own adapter implementation. Credentials are encrypted using Fernet with master key stored in OS keychain. OAuth providers use local redirect server for authentication.
+
+**Tech Stack:** Python (smbprotocol, aioboto3, keyring, cryptography, aiohttp), React (TypeScript, shadcn/ui)
+
+---
+
+## Phase 1: Foundation
+
+### Task 1: Database Migration - Add subtype Column
+
+**Files:**
+- Create: `packages/backend/migrations/add_storage_subtype.py`
+- Modify: `packages/backend/persistence/models.py:282-294`
+
+**Step 1: Create migration script**
+
+```python
+# packages/backend/migrations/add_storage_subtype.py
+"""Add subtype column to storage_locations table."""
+
+import sqlite3
+from pathlib import Path
+
+
+def migrate(db_path: Path) -> None:
+    """Add subtype column to storage_locations."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Check if column already exists
+    cursor.execute("PRAGMA table_info(storage_locations)")
+    columns = [col[1] for col in cursor.fetchall()]
+
+    if "subtype" not in columns:
+        cursor.execute(
+            "ALTER TABLE storage_locations ADD COLUMN subtype VARCHAR(50)"
+        )
+        conn.commit()
+        print("Added subtype column to storage_locations")
+    else:
+        print("subtype column already exists")
+
+    # Add status column for health tracking
+    if "status" not in columns:
+        cursor.execute(
+            "ALTER TABLE storage_locations ADD COLUMN status VARCHAR(20) DEFAULT 'healthy'"
+        )
+        conn.commit()
+        print("Added status column to storage_locations")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    db_path = Path(__file__).parent.parent / "verbatim.db"
+    migrate(db_path)
+```
+
+**Step 2: Update SQLAlchemy model**
+
+In `packages/backend/persistence/models.py`, update StorageLocation class:
+
+```python
+class StorageLocation(Base):
+    """Configurable storage location for files (local, network, cloud)."""
+
+    __tablename__ = "storage_locations"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    type: Mapped[str] = mapped_column(String(50), nullable=False)  # "local", "network", "cloud"
+    subtype: Mapped[str | None] = mapped_column(String(50))  # "smb", "nfs", "s3", "gdrive", etc.
+    config: Mapped[dict] = mapped_column(JSON, default=dict)
+    is_default: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    status: Mapped[str] = mapped_column(String(20), default="healthy")  # healthy, degraded, unreachable, auth_expired
+    created_at: Mapped[datetime] = mapped_column(default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(default=func.now(), onupdate=func.now())
+```
+
+**Step 3: Run migration**
+
+```bash
+cd packages/backend
+python migrations/add_storage_subtype.py
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/backend/migrations/add_storage_subtype.py packages/backend/persistence/models.py
+git commit -m "feat: add subtype and status columns to storage_locations
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Create Encryption Service
+
+**Files:**
+- Create: `packages/backend/services/encryption.py`
+- Create: `packages/backend/tests/test_encryption.py`
+
+**Step 1: Write the failing test**
+
+```python
+# packages/backend/tests/test_encryption.py
+"""Tests for credential encryption service."""
+
+import pytest
+from services.encryption import encrypt_config, decrypt_config, SENSITIVE_FIELDS
+
+
+def test_encrypt_decrypt_roundtrip():
+    """Encrypted config should decrypt back to original."""
+    original = {
+        "bucket": "my-bucket",
+        "region": "us-east-1",
+        "access_key": "AKIAIOSFODNN7EXAMPLE",
+        "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    }
+
+    encrypted = encrypt_config(original)
+
+    # Non-sensitive fields unchanged
+    assert encrypted["bucket"] == "my-bucket"
+    assert encrypted["region"] == "us-east-1"
+    assert encrypted["access_key"] == "AKIAIOSFODNN7EXAMPLE"
+
+    # Sensitive field is encrypted
+    assert "_encrypted" in encrypted["secret_key"]
+    assert encrypted["secret_key"]["_encrypted"] != original["secret_key"]
+
+    # Decrypt back
+    decrypted = decrypt_config(encrypted)
+    assert decrypted == original
+
+
+def test_encrypt_empty_config():
+    """Empty config should remain empty."""
+    assert encrypt_config({}) == {}
+    assert decrypt_config({}) == {}
+
+
+def test_encrypt_none_values():
+    """None values should be preserved."""
+    config = {"password": None, "username": "admin"}
+    encrypted = encrypt_config(config)
+    assert encrypted["password"] is None
+    assert encrypted["username"] == "admin"
+
+
+def test_sensitive_fields_list():
+    """Verify expected sensitive fields."""
+    expected = {
+        "password", "secret_key", "account_key", "connection_string",
+        "credentials_json", "oauth_tokens", "access_token", "refresh_token"
+    }
+    assert SENSITIVE_FIELDS == expected
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd packages/backend
+python -m pytest tests/test_encryption.py -v
+```
+
+Expected: FAIL with "ModuleNotFoundError: No module named 'services.encryption'"
+
+**Step 3: Write the implementation**
+
+```python
+# packages/backend/services/encryption.py
+"""Credential encryption service using Fernet with OS keychain."""
+
+import base64
+import json
+import logging
+import os
+from pathlib import Path
+
+import keyring
+from cryptography.fernet import Fernet
+
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME = "verbatim-studio"
+KEY_NAME = "master-key"
+FALLBACK_PATH = Path.home() / ".verbatim-studio" / ".keyfile"
+
+SENSITIVE_FIELDS = {
+    "password",
+    "secret_key",
+    "account_key",
+    "connection_string",
+    "credentials_json",
+    "oauth_tokens",
+    "access_token",
+    "refresh_token",
+}
+
+
+def get_master_key() -> bytes:
+    """Get or create master encryption key.
+
+    Tries OS keychain first, falls back to file-based storage.
+    """
+    # Try OS keychain first
+    try:
+        key = keyring.get_password(SERVICE_NAME, KEY_NAME)
+        if key:
+            return base64.b64decode(key)
+    except Exception as e:
+        logger.debug(f"Keyring unavailable: {e}")
+
+    # Try fallback file
+    if FALLBACK_PATH.exists():
+        return FALLBACK_PATH.read_bytes()
+
+    # Generate new key
+    new_key = Fernet.generate_key()
+
+    # Try to store in keychain
+    try:
+        keyring.set_password(SERVICE_NAME, KEY_NAME, base64.b64encode(new_key).decode())
+        logger.info("Master key stored in OS keychain")
+        return new_key
+    except Exception as e:
+        logger.warning(f"Could not store key in keychain: {e}")
+
+    # Fall back to file
+    FALLBACK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    FALLBACK_PATH.write_bytes(new_key)
+    FALLBACK_PATH.chmod(0o600)
+    logger.warning(f"Master key stored in fallback file: {FALLBACK_PATH}")
+    return new_key
+
+
+def get_fernet() -> Fernet:
+    """Get Fernet instance with master key."""
+    return Fernet(get_master_key())
+
+
+def encrypt_config(config: dict) -> dict:
+    """Encrypt sensitive fields in config.
+
+    Non-sensitive fields are left as-is.
+    Sensitive fields become {"_encrypted": "base64-ciphertext"}.
+    """
+    if not config:
+        return config
+
+    fernet = get_fernet()
+    result = {}
+
+    for key, value in config.items():
+        if key in SENSITIVE_FIELDS and value is not None:
+            encrypted = fernet.encrypt(json.dumps(value).encode())
+            result[key] = {"_encrypted": base64.b64encode(encrypted).decode()}
+        else:
+            result[key] = value
+
+    return result
+
+
+def decrypt_config(config: dict) -> dict:
+    """Decrypt sensitive fields in config.
+
+    Fields with {"_encrypted": ...} are decrypted.
+    Other fields are left as-is.
+    """
+    if not config:
+        return config
+
+    fernet = get_fernet()
+    result = {}
+
+    for key, value in config.items():
+        if isinstance(value, dict) and "_encrypted" in value:
+            try:
+                decrypted = fernet.decrypt(base64.b64decode(value["_encrypted"]))
+                result[key] = json.loads(decrypted.decode())
+            except Exception as e:
+                logger.error(f"Failed to decrypt {key}: {e}")
+                result[key] = None
+        else:
+            result[key] = value
+
+    return result
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd packages/backend
+python -m pytest tests/test_encryption.py -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/backend/services/encryption.py packages/backend/tests/test_encryption.py
+git commit -m "feat: add credential encryption service with keychain support
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Create Storage Adapter Base Class
+
+**Files:**
+- Create: `packages/backend/storage/__init__.py`
+- Create: `packages/backend/storage/base.py`
+- Create: `packages/backend/storage/exceptions.py`
+
+**Step 1: Create the package and base classes**
+
+```python
+# packages/backend/storage/__init__.py
+"""Storage adapter package."""
+
+from storage.base import StorageAdapter, FileInfo
+from storage.exceptions import (
+    StorageError,
+    StorageUnavailableError,
+    StorageAuthError,
+    StorageNotFoundError,
+    StoragePermissionError,
+)
+
+__all__ = [
+    "StorageAdapter",
+    "FileInfo",
+    "StorageError",
+    "StorageUnavailableError",
+    "StorageAuthError",
+    "StorageNotFoundError",
+    "StoragePermissionError",
+]
+```
+
+```python
+# packages/backend/storage/exceptions.py
+"""Storage adapter exceptions."""
+
+
+class StorageError(Exception):
+    """Base storage error."""
+    pass
+
+
+class StorageUnavailableError(StorageError):
+    """Storage location is unreachable."""
+    pass
+
+
+class StorageAuthError(StorageError):
+    """Authentication failed or expired."""
+    pass
+
+
+class StorageNotFoundError(StorageError):
+    """File or directory not found."""
+    pass
+
+
+class StoragePermissionError(StorageError):
+    """Permission denied."""
+    pass
+```
+
+```python
+# packages/backend/storage/base.py
+"""Base storage adapter interface."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import AsyncIterator
+
+
+@dataclass
+class FileInfo:
+    """Information about a file or directory."""
+
+    name: str
+    path: str
+    size: int
+    is_directory: bool
+    modified_at: datetime
+    mime_type: str | None = None
+
+
+class StorageAdapter(ABC):
+    """Abstract base class for storage adapters.
+
+    All storage backends (local, network, cloud) implement this interface.
+    """
+
+    @abstractmethod
+    async def test_connection(self) -> bool:
+        """Verify connectivity and credentials.
+
+        Returns True if connection successful.
+        Raises StorageError subclass on failure.
+        """
+        ...
+
+    @abstractmethod
+    async def list_files(self, path: str = "") -> list[FileInfo]:
+        """List files and directories at path.
+
+        Args:
+            path: Relative path within storage location. Empty string for root.
+
+        Returns:
+            List of FileInfo objects.
+
+        Raises:
+            StorageNotFoundError: If path doesn't exist.
+            StoragePermissionError: If access denied.
+        """
+        ...
+
+    @abstractmethod
+    async def read_file(self, path: str) -> bytes:
+        """Read file contents.
+
+        Args:
+            path: Relative path to file.
+
+        Returns:
+            File contents as bytes.
+
+        Raises:
+            StorageNotFoundError: If file doesn't exist.
+        """
+        ...
+
+    @abstractmethod
+    async def write_file(self, path: str, data: bytes) -> None:
+        """Write data to file.
+
+        Creates parent directories as needed.
+        Overwrites existing file.
+
+        Args:
+            path: Relative path to file.
+            data: File contents.
+        """
+        ...
+
+    @abstractmethod
+    async def delete_file(self, path: str) -> None:
+        """Delete a file.
+
+        Args:
+            path: Relative path to file.
+
+        Raises:
+            StorageNotFoundError: If file doesn't exist.
+        """
+        ...
+
+    @abstractmethod
+    async def exists(self, path: str) -> bool:
+        """Check if file or directory exists.
+
+        Args:
+            path: Relative path to check.
+
+        Returns:
+            True if exists, False otherwise.
+        """
+        ...
+
+    @abstractmethod
+    async def get_file_info(self, path: str) -> FileInfo:
+        """Get metadata for a single file.
+
+        Args:
+            path: Relative path to file.
+
+        Returns:
+            FileInfo object.
+
+        Raises:
+            StorageNotFoundError: If file doesn't exist.
+        """
+        ...
+
+    @abstractmethod
+    async def ensure_directory(self, path: str) -> None:
+        """Create directory and parents if they don't exist.
+
+        Args:
+            path: Relative path to directory.
+        """
+        ...
+
+    async def stream_file(self, path: str, chunk_size: int = 8192) -> AsyncIterator[bytes]:
+        """Stream file contents in chunks.
+
+        Default implementation reads entire file. Subclasses can override
+        for more efficient streaming.
+
+        Args:
+            path: Relative path to file.
+            chunk_size: Size of each chunk in bytes.
+
+        Yields:
+            File content chunks.
+        """
+        data = await self.read_file(path)
+        for i in range(0, len(data), chunk_size):
+            yield data[i:i + chunk_size]
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/backend/storage/
+git commit -m "feat: add storage adapter base class and exceptions
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Implement LocalAdapter
+
+**Files:**
+- Create: `packages/backend/storage/adapters/__init__.py`
+- Create: `packages/backend/storage/adapters/local.py`
+- Create: `packages/backend/tests/test_storage_local.py`
+
+**Step 1: Write the failing test**
+
+```python
+# packages/backend/tests/test_storage_local.py
+"""Tests for local storage adapter."""
+
+import pytest
+from pathlib import Path
+import tempfile
+import shutil
+
+from storage.adapters.local import LocalAdapter
+from storage.exceptions import StorageNotFoundError
+
+
+@pytest.fixture
+def temp_storage():
+    """Create a temporary directory for testing."""
+    path = Path(tempfile.mkdtemp())
+    yield path
+    shutil.rmtree(path)
+
+
+@pytest.fixture
+def adapter(temp_storage):
+    """Create a LocalAdapter for the temp directory."""
+    return LocalAdapter({"path": str(temp_storage)})
+
+
+@pytest.mark.asyncio
+async def test_test_connection(adapter, temp_storage):
+    """Test connection should succeed for valid path."""
+    assert await adapter.test_connection() is True
+
+
+@pytest.mark.asyncio
+async def test_test_connection_invalid_path():
+    """Test connection should fail for non-existent path."""
+    adapter = LocalAdapter({"path": "/nonexistent/path/12345"})
+    with pytest.raises(Exception):
+        await adapter.test_connection()
+
+
+@pytest.mark.asyncio
+async def test_write_and_read_file(adapter, temp_storage):
+    """Write then read file."""
+    await adapter.write_file("test.txt", b"hello world")
+
+    content = await adapter.read_file("test.txt")
+    assert content == b"hello world"
+
+    # Verify file exists on disk
+    assert (temp_storage / "test.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_creates_directories(adapter, temp_storage):
+    """Write should create parent directories."""
+    await adapter.write_file("a/b/c/test.txt", b"nested")
+
+    assert (temp_storage / "a/b/c/test.txt").exists()
+    content = await adapter.read_file("a/b/c/test.txt")
+    assert content == b"nested"
+
+
+@pytest.mark.asyncio
+async def test_exists(adapter, temp_storage):
+    """Check file and directory existence."""
+    assert await adapter.exists("missing.txt") is False
+
+    await adapter.write_file("exists.txt", b"data")
+    assert await adapter.exists("exists.txt") is True
+
+    await adapter.ensure_directory("subdir")
+    assert await adapter.exists("subdir") is True
+
+
+@pytest.mark.asyncio
+async def test_delete_file(adapter, temp_storage):
+    """Delete a file."""
+    await adapter.write_file("to_delete.txt", b"bye")
+    assert await adapter.exists("to_delete.txt") is True
+
+    await adapter.delete_file("to_delete.txt")
+    assert await adapter.exists("to_delete.txt") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_raises(adapter):
+    """Delete non-existent file should raise."""
+    with pytest.raises(StorageNotFoundError):
+        await adapter.delete_file("nonexistent.txt")
+
+
+@pytest.mark.asyncio
+async def test_list_files(adapter, temp_storage):
+    """List files in directory."""
+    await adapter.write_file("file1.txt", b"a")
+    await adapter.write_file("file2.txt", b"b")
+    await adapter.ensure_directory("subdir")
+
+    files = await adapter.list_files("")
+    names = {f.name for f in files}
+
+    assert "file1.txt" in names
+    assert "file2.txt" in names
+    assert "subdir" in names
+
+    # Check file info
+    file1 = next(f for f in files if f.name == "file1.txt")
+    assert file1.size == 1
+    assert file1.is_directory is False
+
+    subdir = next(f for f in files if f.name == "subdir")
+    assert subdir.is_directory is True
+
+
+@pytest.mark.asyncio
+async def test_get_file_info(adapter, temp_storage):
+    """Get info for specific file."""
+    await adapter.write_file("info_test.txt", b"test content")
+
+    info = await adapter.get_file_info("info_test.txt")
+
+    assert info.name == "info_test.txt"
+    assert info.size == 12
+    assert info.is_directory is False
+    assert info.mime_type == "text/plain"
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd packages/backend
+python -m pytest tests/test_storage_local.py -v
+```
+
+Expected: FAIL with "ModuleNotFoundError"
+
+**Step 3: Write the implementation**
+
+```python
+# packages/backend/storage/adapters/__init__.py
+"""Storage adapter implementations."""
+
+from storage.adapters.local import LocalAdapter
+
+__all__ = ["LocalAdapter"]
+```
+
+```python
+# packages/backend/storage/adapters/local.py
+"""Local filesystem storage adapter."""
+
+import mimetypes
+from datetime import datetime
+from pathlib import Path
+
+import aiofiles
+import aiofiles.os
+
+from storage.base import StorageAdapter, FileInfo
+from storage.exceptions import (
+    StorageNotFoundError,
+    StoragePermissionError,
+    StorageUnavailableError,
+)
+
+
+class LocalAdapter(StorageAdapter):
+    """Storage adapter for local filesystem."""
+
+    def __init__(self, config: dict):
+        """Initialize with config containing 'path'."""
+        self.base_path = Path(config["path"])
+
+    def _resolve_path(self, path: str) -> Path:
+        """Resolve relative path to absolute, preventing traversal."""
+        if not path:
+            return self.base_path
+
+        resolved = (self.base_path / path).resolve()
+
+        # Prevent directory traversal
+        if not str(resolved).startswith(str(self.base_path.resolve())):
+            raise StoragePermissionError(f"Path traversal not allowed: {path}")
+
+        return resolved
+
+    async def test_connection(self) -> bool:
+        """Verify base path exists and is writable."""
+        if not self.base_path.exists():
+            raise StorageUnavailableError(f"Path does not exist: {self.base_path}")
+
+        if not self.base_path.is_dir():
+            raise StorageUnavailableError(f"Path is not a directory: {self.base_path}")
+
+        # Test write access
+        test_file = self.base_path / ".write_test"
+        try:
+            test_file.touch()
+            test_file.unlink()
+        except PermissionError:
+            raise StoragePermissionError(f"Cannot write to: {self.base_path}")
+
+        return True
+
+    async def list_files(self, path: str = "") -> list[FileInfo]:
+        """List files in directory."""
+        dir_path = self._resolve_path(path)
+
+        if not dir_path.exists():
+            raise StorageNotFoundError(f"Directory not found: {path}")
+
+        if not dir_path.is_dir():
+            raise StorageNotFoundError(f"Not a directory: {path}")
+
+        files = []
+        for item in dir_path.iterdir():
+            stat = item.stat()
+            mime_type = None
+            if item.is_file():
+                mime_type, _ = mimetypes.guess_type(str(item))
+
+            files.append(FileInfo(
+                name=item.name,
+                path=str(item.relative_to(self.base_path)),
+                size=stat.st_size if item.is_file() else 0,
+                is_directory=item.is_dir(),
+                modified_at=datetime.fromtimestamp(stat.st_mtime),
+                mime_type=mime_type,
+            ))
+
+        return files
+
+    async def read_file(self, path: str) -> bytes:
+        """Read file contents."""
+        file_path = self._resolve_path(path)
+
+        if not file_path.exists():
+            raise StorageNotFoundError(f"File not found: {path}")
+
+        if not file_path.is_file():
+            raise StorageNotFoundError(f"Not a file: {path}")
+
+        async with aiofiles.open(file_path, "rb") as f:
+            return await f.read()
+
+    async def write_file(self, path: str, data: bytes) -> None:
+        """Write data to file, creating directories as needed."""
+        file_path = self._resolve_path(path)
+
+        # Create parent directories
+        await aiofiles.os.makedirs(file_path.parent, exist_ok=True)
+
+        async with aiofiles.open(file_path, "wb") as f:
+            await f.write(data)
+
+    async def delete_file(self, path: str) -> None:
+        """Delete a file."""
+        file_path = self._resolve_path(path)
+
+        if not file_path.exists():
+            raise StorageNotFoundError(f"File not found: {path}")
+
+        await aiofiles.os.remove(file_path)
+
+    async def exists(self, path: str) -> bool:
+        """Check if path exists."""
+        return self._resolve_path(path).exists()
+
+    async def get_file_info(self, path: str) -> FileInfo:
+        """Get file metadata."""
+        file_path = self._resolve_path(path)
+
+        if not file_path.exists():
+            raise StorageNotFoundError(f"File not found: {path}")
+
+        stat = file_path.stat()
+        mime_type = None
+        if file_path.is_file():
+            mime_type, _ = mimetypes.guess_type(str(file_path))
+
+        return FileInfo(
+            name=file_path.name,
+            path=path,
+            size=stat.st_size if file_path.is_file() else 0,
+            is_directory=file_path.is_dir(),
+            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            mime_type=mime_type,
+        )
+
+    async def ensure_directory(self, path: str) -> None:
+        """Create directory and parents."""
+        dir_path = self._resolve_path(path)
+        await aiofiles.os.makedirs(dir_path, exist_ok=True)
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd packages/backend
+python -m pytest tests/test_storage_local.py -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/backend/storage/adapters/
+git add packages/backend/tests/test_storage_local.py
+git commit -m "feat: implement LocalAdapter for filesystem storage
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Create Adapter Factory
+
+**Files:**
+- Create: `packages/backend/storage/factory.py`
+- Create: `packages/backend/tests/test_storage_factory.py`
+
+**Step 1: Write the failing test**
+
+```python
+# packages/backend/tests/test_storage_factory.py
+"""Tests for storage adapter factory."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from storage.factory import get_adapter
+from storage.adapters.local import LocalAdapter
+
+
+def test_get_local_adapter():
+    """Factory returns LocalAdapter for local type."""
+    location = MagicMock()
+    location.type = "local"
+    location.subtype = None
+    location.config = {"path": "/tmp/test"}
+
+    adapter = get_adapter(location)
+
+    assert isinstance(adapter, LocalAdapter)
+
+
+def test_get_adapter_unknown_type():
+    """Factory raises for unknown type."""
+    location = MagicMock()
+    location.type = "unknown"
+    location.subtype = None
+    location.config = {}
+
+    with pytest.raises(ValueError, match="Unknown storage type"):
+        get_adapter(location)
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd packages/backend
+python -m pytest tests/test_storage_factory.py -v
+```
+
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```python
+# packages/backend/storage/factory.py
+"""Storage adapter factory."""
+
+from persistence.models import StorageLocation
+from services.encryption import decrypt_config
+from storage.base import StorageAdapter
+from storage.adapters.local import LocalAdapter
+
+
+# Registry of adapter classes by (type, subtype)
+ADAPTER_REGISTRY: dict[tuple[str, str | None], type[StorageAdapter]] = {
+    ("local", None): LocalAdapter,
+}
+
+
+def get_adapter(location: StorageLocation) -> StorageAdapter:
+    """Get appropriate storage adapter for a location.
+
+    Args:
+        location: StorageLocation model instance.
+
+    Returns:
+        Configured StorageAdapter instance.
+
+    Raises:
+        ValueError: If storage type is not supported.
+    """
+    key = (location.type, location.subtype)
+
+    # Try exact match first
+    adapter_class = ADAPTER_REGISTRY.get(key)
+
+    # Fall back to type-only match
+    if adapter_class is None:
+        adapter_class = ADAPTER_REGISTRY.get((location.type, None))
+
+    if adapter_class is None:
+        raise ValueError(
+            f"Unknown storage type: {location.type}/{location.subtype}"
+        )
+
+    # Decrypt credentials before passing to adapter
+    config = decrypt_config(location.config or {})
+
+    return adapter_class(config)
+
+
+def register_adapter(
+    storage_type: str,
+    subtype: str | None,
+    adapter_class: type[StorageAdapter]
+) -> None:
+    """Register an adapter class for a storage type.
+
+    Args:
+        storage_type: Primary type (local, network, cloud).
+        subtype: Subtype (smb, s3, gdrive, etc.) or None.
+        adapter_class: StorageAdapter subclass.
+    """
+    ADAPTER_REGISTRY[(storage_type, subtype)] = adapter_class
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd packages/backend
+python -m pytest tests/test_storage_factory.py -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/backend/storage/factory.py packages/backend/tests/test_storage_factory.py
+git commit -m "feat: add storage adapter factory with registry
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Update API Routes for New Schema
+
+**Files:**
+- Modify: `packages/backend/api/routes/storage_locations.py`
+- Create: `packages/backend/tests/test_storage_locations_api.py`
+
+**Step 1: Update the Pydantic models and add test endpoint**
+
+Update `packages/backend/api/routes/storage_locations.py`:
+
+```python
+"""Storage location management endpoints."""
+
+import asyncio
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
+
+from persistence.database import async_session
+from persistence.models import StorageLocation
+from services.encryption import encrypt_config, decrypt_config
+from storage.factory import get_adapter
+from storage.exceptions import StorageError, StorageAuthError, StorageUnavailableError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/storage-locations", tags=["storage-locations"])
+
+# Track migration progress in memory
+_migration_progress: dict[str, dict] = {}
+
+
+class StorageLocationConfig(BaseModel):
+    """Storage location configuration (varies by type)."""
+
+    # Local
+    path: str | None = None
+
+    # Network - SMB
+    server: str | None = None
+    share: str | None = None
+    username: str | None = None
+    password: str | None = None
+    domain: str | None = None
+
+    # Network - NFS
+    export_path: str | None = None
+    mount_options: str | None = None
+
+    # Cloud - S3
+    bucket: str | None = None
+    region: str | None = None
+    access_key: str | None = None
+    secret_key: str | None = None
+    endpoint: str | None = None
+
+    # Cloud - Azure
+    container: str | None = None
+    account_name: str | None = None
+    account_key: str | None = None
+    connection_string: str | None = None
+
+    # Cloud - GCS
+    project_id: str | None = None
+    credentials_json: str | None = None
+
+    # Cloud - OAuth (GDrive, OneDrive, Dropbox)
+    folder_id: str | None = None
+    folder_path: str | None = None
+    oauth_tokens: dict | None = None
+
+    class Config:
+        extra = "allow"  # Allow additional fields
+
+
+class StorageLocationResponse(BaseModel):
+    """Storage location response model."""
+
+    id: str
+    name: str
+    type: str
+    subtype: str | None
+    config: dict[str, Any]  # Only non-sensitive fields
+    is_default: bool
+    is_active: bool
+    status: str
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_model(cls, loc: StorageLocation) -> "StorageLocationResponse":
+        # Return config without sensitive fields for display
+        safe_config = {}
+        sensitive = {"password", "secret_key", "account_key", "connection_string",
+                    "credentials_json", "oauth_tokens", "access_token", "refresh_token"}
+
+        for key, value in (loc.config or {}).items():
+            if key in sensitive:
+                safe_config[key] = "***" if value else None
+            elif isinstance(value, dict) and "_encrypted" in value:
+                safe_config[key] = "***"
+            else:
+                safe_config[key] = value
+
+        return cls(
+            id=loc.id,
+            name=loc.name,
+            type=loc.type,
+            subtype=loc.subtype,
+            config=safe_config,
+            is_default=loc.is_default,
+            is_active=loc.is_active,
+            status=loc.status or "healthy",
+            created_at=loc.created_at.isoformat() if loc.created_at else "",
+            updated_at=loc.updated_at.isoformat() if loc.updated_at else "",
+        )
+
+
+class StorageLocationListResponse(BaseModel):
+    """List of storage locations."""
+
+    items: list[StorageLocationResponse]
+    total: int
+
+
+class StorageLocationCreate(BaseModel):
+    """Create a storage location."""
+
+    name: str
+    type: str = "local"
+    subtype: str | None = None
+    config: StorageLocationConfig
+    is_default: bool = False
+
+
+class StorageLocationUpdate(BaseModel):
+    """Update a storage location."""
+
+    name: str | None = None
+    config: StorageLocationConfig | None = None
+    is_default: bool | None = None
+    is_active: bool | None = None
+
+
+class TestConnectionRequest(BaseModel):
+    """Request to test a storage connection."""
+
+    type: str
+    subtype: str | None = None
+    config: StorageLocationConfig
+
+
+class TestConnectionResponse(BaseModel):
+    """Response from connection test."""
+
+    success: bool
+    error: str | None = None
+    latency_ms: float | None = None
+
+
+@router.post("/test", response_model=TestConnectionResponse)
+async def test_connection(body: TestConnectionRequest) -> TestConnectionResponse:
+    """Test a storage connection before saving.
+
+    This validates credentials and connectivity without creating a location.
+    """
+    import time
+
+    # Create a mock location for the factory
+    class MockLocation:
+        def __init__(self, type_: str, subtype: str | None, config: dict):
+            self.type = type_
+            self.subtype = subtype
+            self.config = config
+
+    config_dict = body.config.model_dump(exclude_none=True)
+    mock_loc = MockLocation(body.type, body.subtype, config_dict)
+
+    try:
+        start = time.monotonic()
+        adapter = get_adapter(mock_loc)
+        await adapter.test_connection()
+        elapsed = (time.monotonic() - start) * 1000
+
+        return TestConnectionResponse(success=True, latency_ms=elapsed)
+
+    except StorageAuthError as e:
+        return TestConnectionResponse(success=False, error=f"Authentication failed: {e}")
+    except StorageUnavailableError as e:
+        return TestConnectionResponse(success=False, error=f"Cannot connect: {e}")
+    except StorageError as e:
+        return TestConnectionResponse(success=False, error=str(e))
+    except ValueError as e:
+        return TestConnectionResponse(success=False, error=str(e))
+    except Exception as e:
+        logger.exception("Connection test failed")
+        return TestConnectionResponse(success=False, error=f"Unexpected error: {e}")
+
+
+# ... rest of existing endpoints with updated encryption handling ...
+```
+
+**Step 2: Write API test**
+
+```python
+# packages/backend/tests/test_storage_locations_api.py
+"""Tests for storage locations API endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+import tempfile
+from pathlib import Path
+
+from api.main import app
+
+
+@pytest.fixture
+def client():
+    """Create test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory."""
+    path = Path(tempfile.mkdtemp())
+    yield path
+    import shutil
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def test_test_connection_local_valid(client, temp_dir):
+    """Test connection should succeed for valid local path."""
+    response = client.post("/api/storage-locations/test", json={
+        "type": "local",
+        "config": {"path": str(temp_dir)}
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["latency_ms"] is not None
+
+
+def test_test_connection_local_invalid(client):
+    """Test connection should fail for invalid path."""
+    response = client.post("/api/storage-locations/test", json={
+        "type": "local",
+        "config": {"path": "/nonexistent/path/xyz123"}
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    assert "Cannot connect" in data["error"] or "not exist" in data["error"].lower()
+
+
+def test_test_connection_unknown_type(client):
+    """Test connection should fail for unknown type."""
+    response = client.post("/api/storage-locations/test", json={
+        "type": "unknown_type",
+        "config": {}
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    assert "Unknown storage type" in data["error"]
+```
+
+**Step 3: Run tests**
+
+```bash
+cd packages/backend
+python -m pytest tests/test_storage_locations_api.py -v
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/backend/api/routes/storage_locations.py
+git add packages/backend/tests/test_storage_locations_api.py
+git commit -m "feat: add test connection endpoint and update API schema
+
+- Add POST /storage-locations/test endpoint
+- Update schema to include subtype and all config fields
+- Mask sensitive fields in responses
+- Encrypt credentials before storage
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Update Frontend Types and API Client
+
+**Files:**
+- Modify: `packages/frontend/src/lib/api.ts`
+
+**Step 1: Update TypeScript interfaces**
+
+In `packages/frontend/src/lib/api.ts`, update the storage location types:
+
+```typescript
+// Storage Locations
+export type StorageType = 'local' | 'network' | 'cloud';
+export type StorageSubtype =
+  | null
+  | 'smb' | 'nfs'  // network
+  | 's3' | 'azure' | 'gcs' | 'gdrive' | 'onedrive' | 'dropbox';  // cloud
+
+export interface StorageLocationConfig {
+  // Local
+  path?: string;
+
+  // Network - SMB
+  server?: string;
+  share?: string;
+  username?: string;
+  password?: string;
+  domain?: string;
+
+  // Network - NFS
+  export_path?: string;
+  mount_options?: string;
+
+  // Cloud - S3
+  bucket?: string;
+  region?: string;
+  access_key?: string;
+  secret_key?: string;
+  endpoint?: string;
+
+  // Cloud - Azure
+  container?: string;
+  account_name?: string;
+  account_key?: string;
+  connection_string?: string;
+
+  // Cloud - GCS
+  project_id?: string;
+  credentials_json?: string;
+
+  // Cloud - OAuth
+  folder_id?: string;
+  folder_path?: string;
+  oauth_tokens?: Record<string, unknown>;
+
+  [key: string]: unknown;
+}
+
+export interface StorageLocation {
+  id: string;
+  name: string;
+  type: StorageType;
+  subtype: StorageSubtype;
+  config: StorageLocationConfig;
+  is_default: boolean;
+  is_active: boolean;
+  status: 'healthy' | 'degraded' | 'unreachable' | 'auth_expired';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface StorageLocationListResponse {
+  items: StorageLocation[];
+  total: number;
+}
+
+export interface StorageLocationCreate {
+  name: string;
+  type?: StorageType;
+  subtype?: StorageSubtype;
+  config: StorageLocationConfig;
+  is_default?: boolean;
+}
+
+export interface StorageLocationUpdate {
+  name?: string;
+  config?: StorageLocationConfig;
+  is_default?: boolean;
+  is_active?: boolean;
+}
+
+export interface TestConnectionRequest {
+  type: StorageType;
+  subtype?: StorageSubtype;
+  config: StorageLocationConfig;
+}
+
+export interface TestConnectionResponse {
+  success: boolean;
+  error?: string;
+  latency_ms?: number;
+}
+```
+
+Also update the API client methods:
+
+```typescript
+  storageLocations = {
+    list: () => this.request<StorageLocationListResponse>('/api/storage-locations'),
+
+    get: (id: string) => this.request<StorageLocation>(`/api/storage-locations/${id}`),
+
+    create: (data: StorageLocationCreate) =>
+      this.request<StorageLocation>('/api/storage-locations', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+
+    update: (id: string, data: StorageLocationUpdate) =>
+      this.request<StorageLocation>(`/api/storage-locations/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }),
+
+    delete: (id: string) =>
+      this.request<void>(`/api/storage-locations/${id}`, {
+        method: 'DELETE',
+      }),
+
+    test: (data: TestConnectionRequest) =>
+      this.request<TestConnectionResponse>('/api/storage-locations/test', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+
+    migrate: (data: MigrationRequest) =>
+      this.request<MigrationStatus>('/api/storage-locations/migrate', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+
+    getMigrationStatus: () =>
+      this.request<MigrationStatus>('/api/storage-locations/migrate/status'),
+  };
+```
+
+**Step 2: Run TypeScript check**
+
+```bash
+cd packages/frontend
+pnpm tsc --noEmit
+```
+
+**Step 3: Commit**
+
+```bash
+git add packages/frontend/src/lib/api.ts
+git commit -m "feat: update frontend types for storage location types
+
+- Add StorageType and StorageSubtype types
+- Expand StorageLocationConfig with all provider fields
+- Add status field to StorageLocation
+- Add test connection API method
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Create Storage Type Selector Component
+
+**Files:**
+- Create: `packages/frontend/src/components/storage/StorageTypeSelector.tsx`
+
+**Step 1: Create the component**
+
+```tsx
+// packages/frontend/src/components/storage/StorageTypeSelector.tsx
+import { HardDrive, Server, Cloud } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { StorageType } from '@/lib/api';
+
+interface StorageTypeSelectorProps {
+  value: StorageType;
+  onChange: (type: StorageType) => void;
+}
+
+const types: { type: StorageType; label: string; description: string; icon: React.ReactNode }[] = [
+  {
+    type: 'local',
+    label: 'Local Storage',
+    description: 'Folder on this computer',
+    icon: <HardDrive className="w-8 h-8" />,
+  },
+  {
+    type: 'network',
+    label: 'Network Storage',
+    description: 'SMB or NFS share',
+    icon: <Server className="w-8 h-8" />,
+  },
+  {
+    type: 'cloud',
+    label: 'Cloud Storage',
+    description: 'S3, Google Drive, etc.',
+    icon: <Cloud className="w-8 h-8" />,
+  },
+];
+
+export function StorageTypeSelector({ value, onChange }: StorageTypeSelectorProps) {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {types.map(({ type, label, description, icon }) => (
+        <button
+          key={type}
+          type="button"
+          onClick={() => onChange(type)}
+          className={cn(
+            'flex flex-col items-center p-4 rounded-lg border-2 transition-all',
+            'hover:border-primary hover:bg-primary/5',
+            value === type
+              ? 'border-primary bg-primary/10'
+              : 'border-gray-200 dark:border-gray-700'
+          )}
+        >
+          <div className={cn(
+            'mb-2',
+            value === type ? 'text-primary' : 'text-gray-500 dark:text-gray-400'
+          )}>
+            {icon}
+          </div>
+          <span className="font-medium text-sm">{label}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 text-center mt-1">
+            {description}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/frontend/src/components/storage/
+git commit -m "feat: add StorageTypeSelector component
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Create Storage Subtype Selector Component
+
+**Files:**
+- Create: `packages/frontend/src/components/storage/StorageSubtypeSelector.tsx`
+
+**Step 1: Create the component**
+
+```tsx
+// packages/frontend/src/components/storage/StorageSubtypeSelector.tsx
+import { cn } from '@/lib/utils';
+import type { StorageType, StorageSubtype } from '@/lib/api';
+
+interface StorageSubtypeSelectorProps {
+  storageType: StorageType;
+  value: StorageSubtype;
+  onChange: (subtype: StorageSubtype) => void;
+}
+
+const subtypes: Record<StorageType, { subtype: StorageSubtype; label: string; description: string }[]> = {
+  local: [],
+  network: [
+    { subtype: 'smb', label: 'SMB / Windows Share', description: 'Samba, Windows file sharing' },
+    { subtype: 'nfs', label: 'NFS', description: 'Network File System (Unix/Linux)' },
+  ],
+  cloud: [
+    { subtype: 's3', label: 'S3-Compatible', description: 'AWS S3, Backblaze B2, MinIO, Wasabi' },
+    { subtype: 'gdrive', label: 'Google Drive', description: 'Personal or Workspace account' },
+    { subtype: 'onedrive', label: 'OneDrive', description: 'Microsoft OneDrive' },
+    { subtype: 'dropbox', label: 'Dropbox', description: 'Dropbox cloud storage' },
+    { subtype: 'azure', label: 'Azure Blob', description: 'Microsoft Azure Blob Storage' },
+    { subtype: 'gcs', label: 'Google Cloud Storage', description: 'GCS bucket' },
+  ],
+};
+
+export function StorageSubtypeSelector({ storageType, value, onChange }: StorageSubtypeSelectorProps) {
+  const options = subtypes[storageType];
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+        Select Provider
+      </label>
+      <div className="grid grid-cols-2 gap-2">
+        {options.map(({ subtype, label, description }) => (
+          <button
+            key={subtype}
+            type="button"
+            onClick={() => onChange(subtype)}
+            className={cn(
+              'flex flex-col items-start p-3 rounded-lg border transition-all text-left',
+              'hover:border-primary hover:bg-primary/5',
+              value === subtype
+                ? 'border-primary bg-primary/10'
+                : 'border-gray-200 dark:border-gray-700'
+            )}
+          >
+            <span className="font-medium text-sm">{label}</span>
+            <span className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              {description}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/frontend/src/components/storage/StorageSubtypeSelector.tsx
+git commit -m "feat: add StorageSubtypeSelector component
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Create Storage Config Form Component
+
+**Files:**
+- Create: `packages/frontend/src/components/storage/StorageConfigForm.tsx`
+
+**Step 1: Create the component**
+
+```tsx
+// packages/frontend/src/components/storage/StorageConfigForm.tsx
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { StorageType, StorageSubtype, StorageLocationConfig } from '@/lib/api';
+
+interface StorageConfigFormProps {
+  storageType: StorageType;
+  subtype: StorageSubtype;
+  config: StorageLocationConfig;
+  onChange: (config: StorageLocationConfig) => void;
+}
+
+export function StorageConfigForm({ storageType, subtype, config, onChange }: StorageConfigFormProps) {
+  const updateField = (field: string, value: string) => {
+    onChange({ ...config, [field]: value || undefined });
+  };
+
+  // Local storage
+  if (storageType === 'local') {
+    return (
+      <div className="space-y-4">
+        <div>
+          <Label htmlFor="path">Path</Label>
+          <Input
+            id="path"
+            value={config.path || ''}
+            onChange={(e) => updateField('path', e.target.value)}
+            placeholder="/path/to/storage"
+            className="font-mono"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            Full path to a folder. It will be created if it doesn't exist.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // SMB
+  if (storageType === 'network' && subtype === 'smb') {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="server">Server</Label>
+            <Input
+              id="server"
+              value={config.server || ''}
+              onChange={(e) => updateField('server', e.target.value)}
+              placeholder="192.168.1.100 or nas.local"
+            />
+          </div>
+          <div>
+            <Label htmlFor="share">Share Name</Label>
+            <Input
+              id="share"
+              value={config.share || ''}
+              onChange={(e) => updateField('share', e.target.value)}
+              placeholder="media"
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="username">Username</Label>
+            <Input
+              id="username"
+              value={config.username || ''}
+              onChange={(e) => updateField('username', e.target.value)}
+              placeholder="user"
+            />
+          </div>
+          <div>
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={config.password || ''}
+              onChange={(e) => updateField('password', e.target.value)}
+              placeholder="••••••••"
+            />
+          </div>
+        </div>
+        <div>
+          <Label htmlFor="domain">Domain (optional)</Label>
+          <Input
+            id="domain"
+            value={config.domain || ''}
+            onChange={(e) => updateField('domain', e.target.value)}
+            placeholder="WORKGROUP"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // NFS
+  if (storageType === 'network' && subtype === 'nfs') {
+    return (
+      <div className="space-y-4">
+        <div>
+          <Label htmlFor="server">Server</Label>
+          <Input
+            id="server"
+            value={config.server || ''}
+            onChange={(e) => updateField('server', e.target.value)}
+            placeholder="192.168.1.100 or nfs.local"
+          />
+        </div>
+        <div>
+          <Label htmlFor="export_path">Export Path</Label>
+          <Input
+            id="export_path"
+            value={config.export_path || ''}
+            onChange={(e) => updateField('export_path', e.target.value)}
+            placeholder="/exports/media"
+            className="font-mono"
+          />
+        </div>
+        <div>
+          <Label htmlFor="mount_options">Mount Options (optional)</Label>
+          <Input
+            id="mount_options"
+            value={config.mount_options || ''}
+            onChange={(e) => updateField('mount_options', e.target.value)}
+            placeholder="rw,sync"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // S3
+  if (storageType === 'cloud' && subtype === 's3') {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="bucket">Bucket</Label>
+            <Input
+              id="bucket"
+              value={config.bucket || ''}
+              onChange={(e) => updateField('bucket', e.target.value)}
+              placeholder="my-bucket"
+            />
+          </div>
+          <div>
+            <Label htmlFor="region">Region</Label>
+            <Input
+              id="region"
+              value={config.region || ''}
+              onChange={(e) => updateField('region', e.target.value)}
+              placeholder="us-east-1"
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="access_key">Access Key</Label>
+            <Input
+              id="access_key"
+              value={config.access_key || ''}
+              onChange={(e) => updateField('access_key', e.target.value)}
+              placeholder="AKIAIOSFODNN7EXAMPLE"
+              className="font-mono"
+            />
+          </div>
+          <div>
+            <Label htmlFor="secret_key">Secret Key</Label>
+            <Input
+              id="secret_key"
+              type="password"
+              value={config.secret_key || ''}
+              onChange={(e) => updateField('secret_key', e.target.value)}
+              placeholder="••••••••"
+            />
+          </div>
+        </div>
+        <div>
+          <Label htmlFor="endpoint">Custom Endpoint (optional)</Label>
+          <Input
+            id="endpoint"
+            value={config.endpoint || ''}
+            onChange={(e) => updateField('endpoint', e.target.value)}
+            placeholder="https://s3.us-west-001.backblazeb2.com"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            For Backblaze B2, Wasabi, MinIO, etc. Leave empty for AWS S3.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Azure Blob
+  if (storageType === 'cloud' && subtype === 'azure') {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="account_name">Account Name</Label>
+            <Input
+              id="account_name"
+              value={config.account_name || ''}
+              onChange={(e) => updateField('account_name', e.target.value)}
+              placeholder="mystorageaccount"
+            />
+          </div>
+          <div>
+            <Label htmlFor="container">Container</Label>
+            <Input
+              id="container"
+              value={config.container || ''}
+              onChange={(e) => updateField('container', e.target.value)}
+              placeholder="media"
+            />
+          </div>
+        </div>
+        <div>
+          <Label htmlFor="account_key">Account Key</Label>
+          <Input
+            id="account_key"
+            type="password"
+            value={config.account_key || ''}
+            onChange={(e) => updateField('account_key', e.target.value)}
+            placeholder="••••••••"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // GCS
+  if (storageType === 'cloud' && subtype === 'gcs') {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="bucket">Bucket</Label>
+            <Input
+              id="bucket"
+              value={config.bucket || ''}
+              onChange={(e) => updateField('bucket', e.target.value)}
+              placeholder="my-gcs-bucket"
+            />
+          </div>
+          <div>
+            <Label htmlFor="project_id">Project ID</Label>
+            <Input
+              id="project_id"
+              value={config.project_id || ''}
+              onChange={(e) => updateField('project_id', e.target.value)}
+              placeholder="my-project-123"
+            />
+          </div>
+        </div>
+        <div>
+          <Label htmlFor="credentials_json">Service Account JSON</Label>
+          <textarea
+            id="credentials_json"
+            value={config.credentials_json || ''}
+            onChange={(e) => updateField('credentials_json', e.target.value)}
+            placeholder='{"type": "service_account", ...}'
+            className="w-full h-32 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 py-2 px-3 text-sm font-mono"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // OAuth providers (gdrive, onedrive, dropbox) - handled separately with OAuth flow
+  if (storageType === 'cloud' && ['gdrive', 'onedrive', 'dropbox'].includes(subtype || '')) {
+    return (
+      <div className="space-y-4">
+        <div>
+          <Label htmlFor="folder_path">Folder Path (optional)</Label>
+          <Input
+            id="folder_path"
+            value={config.folder_path || config.folder_id || ''}
+            onChange={(e) => updateField(subtype === 'gdrive' ? 'folder_id' : 'folder_path', e.target.value)}
+            placeholder="Verbatim Studio"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            Leave empty to use root folder.
+          </p>
+        </div>
+        <p className="text-sm text-amber-600 dark:text-amber-400">
+          Click "Connect" below to authenticate with {
+            subtype === 'gdrive' ? 'Google' :
+            subtype === 'onedrive' ? 'Microsoft' :
+            'Dropbox'
+          }.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-gray-500 text-sm">
+      Select a storage type and provider to configure.
+    </div>
+  );
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/frontend/src/components/storage/StorageConfigForm.tsx
+git commit -m "feat: add StorageConfigForm with fields for all provider types
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Summary
+
+This implementation plan covers **Phase 1: Foundation** of the storage location types feature:
+
+1. **Task 1**: Database migration for subtype/status columns
+2. **Task 2**: Encryption service for credentials
+3. **Task 3**: Storage adapter base class and exceptions
+4. **Task 4**: LocalAdapter implementation
+5. **Task 5**: Adapter factory with registry
+6. **Task 6**: Updated API routes with test endpoint
+7. **Task 7**: Frontend TypeScript types
+8. **Task 8**: Storage type selector component
+9. **Task 9**: Storage subtype selector component
+10. **Task 10**: Storage config form component
+
+**Remaining phases** (to be planned separately):
+- Phase 2: SMBAdapter and NFSAdapter
+- Phase 3: S3Adapter
+- Phase 4: OAuth providers (GDrive, OneDrive, Dropbox)
+- Phase 5: Azure and GCS adapters
+- Phase 6: Health checks and UI polish

--- a/packages/backend/migrations/add_storage_subtype.py
+++ b/packages/backend/migrations/add_storage_subtype.py
@@ -1,50 +1,62 @@
 """Add subtype column to storage_locations table."""
 
+import logging
 import sqlite3
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def migrate(db_path: Path) -> None:
     """Add subtype column to storage_locations."""
-    conn = sqlite3.connect(db_path)
-    cursor = conn.cursor()
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
 
-    # Check if storage_locations table exists
-    cursor.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='storage_locations'"
-    )
-    if not cursor.fetchone():
-        print("storage_locations table does not exist yet - skipping migration")
-        print("(The table will be created with new columns when the app starts)")
+        # Check if storage_locations table exists
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='storage_locations'"
+        )
+        if not cursor.fetchone():
+            logger.info("storage_locations table does not exist yet - skipping migration")
+            conn.close()
+            return
+
+        # Check if column already exists
+        cursor.execute("PRAGMA table_info(storage_locations)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        if "subtype" not in columns:
+            cursor.execute(
+                "ALTER TABLE storage_locations ADD COLUMN subtype VARCHAR(50)"
+            )
+            conn.commit()
+            logger.info("Added subtype column to storage_locations")
+        else:
+            logger.debug("subtype column already exists")
+
+        # Add status column for health tracking
+        if "status" not in columns:
+            cursor.execute(
+                "ALTER TABLE storage_locations ADD COLUMN status VARCHAR(20) DEFAULT 'healthy'"
+            )
+            conn.commit()
+            logger.info("Added status column to storage_locations")
+        else:
+            logger.debug("status column already exists")
+
         conn.close()
-        return
+        logger.info("Storage subtype migration complete")
 
-    # Check if column already exists
-    cursor.execute("PRAGMA table_info(storage_locations)")
-    columns = [col[1] for col in cursor.fetchall()]
-
-    if "subtype" not in columns:
-        cursor.execute(
-            "ALTER TABLE storage_locations ADD COLUMN subtype VARCHAR(50)"
-        )
-        conn.commit()
-        print("Added subtype column to storage_locations")
-    else:
-        print("subtype column already exists")
-
-    # Add status column for health tracking
-    if "status" not in columns:
-        cursor.execute(
-            "ALTER TABLE storage_locations ADD COLUMN status VARCHAR(20) DEFAULT 'healthy'"
-        )
-        conn.commit()
-        print("Added status column to storage_locations")
-    else:
-        print("status column already exists")
-
-    conn.close()
+    except sqlite3.Error as e:
+        logger.error(f"Database error during storage subtype migration: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error during storage subtype migration: {e}")
+        raise
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     db_path = Path(__file__).parent.parent / "verbatim.db"
     migrate(db_path)

--- a/packages/backend/migrations/add_storage_subtype.py
+++ b/packages/backend/migrations/add_storage_subtype.py
@@ -1,0 +1,50 @@
+"""Add subtype column to storage_locations table."""
+
+import sqlite3
+from pathlib import Path
+
+
+def migrate(db_path: Path) -> None:
+    """Add subtype column to storage_locations."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Check if storage_locations table exists
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='storage_locations'"
+    )
+    if not cursor.fetchone():
+        print("storage_locations table does not exist yet - skipping migration")
+        print("(The table will be created with new columns when the app starts)")
+        conn.close()
+        return
+
+    # Check if column already exists
+    cursor.execute("PRAGMA table_info(storage_locations)")
+    columns = [col[1] for col in cursor.fetchall()]
+
+    if "subtype" not in columns:
+        cursor.execute(
+            "ALTER TABLE storage_locations ADD COLUMN subtype VARCHAR(50)"
+        )
+        conn.commit()
+        print("Added subtype column to storage_locations")
+    else:
+        print("subtype column already exists")
+
+    # Add status column for health tracking
+    if "status" not in columns:
+        cursor.execute(
+            "ALTER TABLE storage_locations ADD COLUMN status VARCHAR(20) DEFAULT 'healthy'"
+        )
+        conn.commit()
+        print("Added status column to storage_locations")
+    else:
+        print("status column already exists")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    db_path = Path(__file__).parent.parent / "verbatim.db"
+    migrate(db_path)

--- a/packages/backend/migrations/add_storage_subtype.py
+++ b/packages/backend/migrations/add_storage_subtype.py
@@ -35,6 +35,10 @@ def migrate(db_path: Path) -> None:
         else:
             logger.debug("subtype column already exists")
 
+        # Refresh column list before checking for status
+        cursor.execute("PRAGMA table_info(storage_locations)")
+        columns = [col[1] for col in cursor.fetchall()]
+
         # Add status column for health tracking
         if "status" not in columns:
             cursor.execute(

--- a/packages/backend/persistence/__init__.py
+++ b/packages/backend/persistence/__init__.py
@@ -15,6 +15,7 @@ from .models import (
     SegmentHighlight,
     Setting,
     Speaker,
+    StorageLocation,
     Tag,
     Transcript,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "SegmentHighlight",
     "Setting",
     "Speaker",
+    "StorageLocation",
     "Tag",
     "Transcript",
 ]

--- a/packages/backend/persistence/models.py
+++ b/packages/backend/persistence/models.py
@@ -280,16 +280,18 @@ class Setting(Base):
 
 
 class StorageLocation(Base):
-    """Configurable storage location for files (local, S3, Azure, GCS)."""
+    """Configurable storage location for files (local, network, cloud)."""
 
     __tablename__ = "storage_locations"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    type: Mapped[str] = mapped_column(String(50), nullable=False)  # "local", "s3", "azure", "gcs"
+    type: Mapped[str] = mapped_column(String(50), nullable=False)  # "local", "network", "cloud"
+    subtype: Mapped[str | None] = mapped_column(String(50))  # "smb", "nfs", "s3", "gdrive", etc.
     config: Mapped[dict] = mapped_column(JSON, default=dict)
     is_default: Mapped[bool] = mapped_column(Boolean, default=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    status: Mapped[str] = mapped_column(String(20), default="healthy")  # "healthy", "degraded", "unreachable", "auth_expired"
     created_at: Mapped[datetime] = mapped_column(default=func.now())
     updated_at: Mapped[datetime] = mapped_column(default=func.now(), onupdate=func.now())
 

--- a/packages/backend/pyproject.toml
+++ b/packages/backend/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "PyMuPDF>=1.24.0",
     # File system watching
     "watchdog>=4.0.0",
+    # Credential encryption
+    "keyring>=25.0.0",
+    "cryptography>=46.0.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/backend/services/encryption.py
+++ b/packages/backend/services/encryption.py
@@ -1,0 +1,116 @@
+"""Credential encryption service using Fernet with OS keychain."""
+
+import base64
+import json
+import logging
+import os
+from pathlib import Path
+
+import keyring
+from cryptography.fernet import Fernet
+
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME = "verbatim-studio"
+KEY_NAME = "master-key"
+FALLBACK_PATH = Path.home() / ".verbatim-studio" / ".keyfile"
+
+SENSITIVE_FIELDS = {
+    "password",
+    "secret_key",
+    "account_key",
+    "connection_string",
+    "credentials_json",
+    "oauth_tokens",
+    "access_token",
+    "refresh_token",
+}
+
+
+def get_master_key() -> bytes:
+    """Get or create master encryption key.
+
+    Tries OS keychain first, falls back to file-based storage.
+    """
+    # Try OS keychain first
+    try:
+        key = keyring.get_password(SERVICE_NAME, KEY_NAME)
+        if key:
+            return base64.b64decode(key)
+    except Exception as e:
+        logger.debug(f"Keyring unavailable: {e}")
+
+    # Try fallback file
+    if FALLBACK_PATH.exists():
+        return FALLBACK_PATH.read_bytes()
+
+    # Generate new key
+    new_key = Fernet.generate_key()
+
+    # Try to store in keychain
+    try:
+        keyring.set_password(SERVICE_NAME, KEY_NAME, base64.b64encode(new_key).decode())
+        logger.info("Master key stored in OS keychain")
+        return new_key
+    except Exception as e:
+        logger.warning(f"Could not store key in keychain: {e}")
+
+    # Fall back to file
+    FALLBACK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    FALLBACK_PATH.write_bytes(new_key)
+    FALLBACK_PATH.chmod(0o600)
+    logger.warning(f"Master key stored in fallback file: {FALLBACK_PATH}")
+    return new_key
+
+
+def get_fernet() -> Fernet:
+    """Get Fernet instance with master key."""
+    return Fernet(get_master_key())
+
+
+def encrypt_config(config: dict) -> dict:
+    """Encrypt sensitive fields in config.
+
+    Non-sensitive fields are left as-is.
+    Sensitive fields become {"_encrypted": "base64-ciphertext"}.
+    """
+    if not config:
+        return config
+
+    fernet = get_fernet()
+    result = {}
+
+    for key, value in config.items():
+        if key in SENSITIVE_FIELDS and value is not None:
+            encrypted = fernet.encrypt(json.dumps(value).encode())
+            result[key] = {"_encrypted": base64.b64encode(encrypted).decode()}
+        else:
+            result[key] = value
+
+    return result
+
+
+def decrypt_config(config: dict) -> dict:
+    """Decrypt sensitive fields in config.
+
+    Fields with {"_encrypted": ...} are decrypted.
+    Other fields are left as-is.
+    """
+    if not config:
+        return config
+
+    fernet = get_fernet()
+    result = {}
+
+    for key, value in config.items():
+        if isinstance(value, dict) and "_encrypted" in value:
+            try:
+                decrypted = fernet.decrypt(base64.b64decode(value["_encrypted"]))
+                result[key] = json.loads(decrypted.decode())
+            except Exception as e:
+                logger.error(f"Failed to decrypt {key}: {e}")
+                result[key] = None
+        else:
+            result[key] = value
+
+    return result

--- a/packages/backend/storage/__init__.py
+++ b/packages/backend/storage/__init__.py
@@ -1,0 +1,21 @@
+# packages/backend/storage/__init__.py
+"""Storage adapter package."""
+
+from storage.base import StorageAdapter, FileInfo
+from storage.exceptions import (
+    StorageError,
+    StorageUnavailableError,
+    StorageAuthError,
+    StorageNotFoundError,
+    StoragePermissionError,
+)
+
+__all__ = [
+    "StorageAdapter",
+    "FileInfo",
+    "StorageError",
+    "StorageUnavailableError",
+    "StorageAuthError",
+    "StorageNotFoundError",
+    "StoragePermissionError",
+]

--- a/packages/backend/storage/adapters/__init__.py
+++ b/packages/backend/storage/adapters/__init__.py
@@ -1,0 +1,6 @@
+# packages/backend/storage/adapters/__init__.py
+"""Storage adapter implementations."""
+
+from storage.adapters.local import LocalAdapter
+
+__all__ = ["LocalAdapter"]

--- a/packages/backend/storage/adapters/local.py
+++ b/packages/backend/storage/adapters/local.py
@@ -1,0 +1,122 @@
+# packages/backend/storage/adapters/local.py
+"""Local filesystem storage adapter."""
+
+import mimetypes
+from datetime import datetime
+from pathlib import Path
+
+import aiofiles
+import aiofiles.os
+
+from storage.base import StorageAdapter, FileInfo
+from storage.exceptions import (
+    StorageNotFoundError,
+    StoragePermissionError,
+    StorageUnavailableError,
+)
+
+
+class LocalAdapter(StorageAdapter):
+    """Storage adapter for local filesystem."""
+
+    def __init__(self, config: dict):
+        """Initialize with config containing 'path'."""
+        self.base_path = Path(config["path"])
+
+    def _resolve_path(self, path: str) -> Path:
+        """Resolve relative path to absolute, preventing traversal."""
+        if not path:
+            return self.base_path
+        resolved = (self.base_path / path).resolve()
+        if not str(resolved).startswith(str(self.base_path.resolve())):
+            raise StoragePermissionError(f"Path traversal not allowed: {path}")
+        return resolved
+
+    async def test_connection(self) -> bool:
+        """Verify base path exists and is writable."""
+        if not self.base_path.exists():
+            raise StorageUnavailableError(f"Path does not exist: {self.base_path}")
+        if not self.base_path.is_dir():
+            raise StorageUnavailableError(f"Path is not a directory: {self.base_path}")
+        test_file = self.base_path / ".write_test"
+        try:
+            test_file.touch()
+            test_file.unlink()
+        except PermissionError:
+            raise StoragePermissionError(f"Cannot write to: {self.base_path}")
+        return True
+
+    async def list_files(self, path: str = "") -> list[FileInfo]:
+        """List files in directory."""
+        dir_path = self._resolve_path(path)
+        if not dir_path.exists():
+            raise StorageNotFoundError(f"Directory not found: {path}")
+        if not dir_path.is_dir():
+            raise StorageNotFoundError(f"Not a directory: {path}")
+
+        files = []
+        for item in dir_path.iterdir():
+            stat = item.stat()
+            mime_type = None
+            if item.is_file():
+                mime_type, _ = mimetypes.guess_type(str(item))
+            files.append(FileInfo(
+                name=item.name,
+                path=str(item.relative_to(self.base_path)),
+                size=stat.st_size if item.is_file() else 0,
+                is_directory=item.is_dir(),
+                modified_at=datetime.fromtimestamp(stat.st_mtime),
+                mime_type=mime_type,
+            ))
+        return files
+
+    async def read_file(self, path: str) -> bytes:
+        """Read file contents."""
+        file_path = self._resolve_path(path)
+        if not file_path.exists():
+            raise StorageNotFoundError(f"File not found: {path}")
+        if not file_path.is_file():
+            raise StorageNotFoundError(f"Not a file: {path}")
+        async with aiofiles.open(file_path, "rb") as f:
+            return await f.read()
+
+    async def write_file(self, path: str, data: bytes) -> None:
+        """Write data to file, creating directories as needed."""
+        file_path = self._resolve_path(path)
+        await aiofiles.os.makedirs(file_path.parent, exist_ok=True)
+        async with aiofiles.open(file_path, "wb") as f:
+            await f.write(data)
+
+    async def delete_file(self, path: str) -> None:
+        """Delete a file."""
+        file_path = self._resolve_path(path)
+        if not file_path.exists():
+            raise StorageNotFoundError(f"File not found: {path}")
+        await aiofiles.os.remove(file_path)
+
+    async def exists(self, path: str) -> bool:
+        """Check if path exists."""
+        return self._resolve_path(path).exists()
+
+    async def get_file_info(self, path: str) -> FileInfo:
+        """Get file metadata."""
+        file_path = self._resolve_path(path)
+        if not file_path.exists():
+            raise StorageNotFoundError(f"File not found: {path}")
+        stat = file_path.stat()
+        mime_type = None
+        if file_path.is_file():
+            mime_type, _ = mimetypes.guess_type(str(file_path))
+        return FileInfo(
+            name=file_path.name,
+            path=path,
+            size=stat.st_size if file_path.is_file() else 0,
+            is_directory=file_path.is_dir(),
+            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            mime_type=mime_type,
+        )
+
+    async def ensure_directory(self, path: str) -> None:
+        """Create directory and parents."""
+        dir_path = self._resolve_path(path)
+        await aiofiles.os.makedirs(dir_path, exist_ok=True)

--- a/packages/backend/storage/base.py
+++ b/packages/backend/storage/base.py
@@ -1,0 +1,72 @@
+# packages/backend/storage/base.py
+"""Base storage adapter interface."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import AsyncIterator
+
+
+@dataclass
+class FileInfo:
+    """Information about a file or directory."""
+
+    name: str
+    path: str
+    size: int
+    is_directory: bool
+    modified_at: datetime
+    mime_type: str | None = None
+
+
+class StorageAdapter(ABC):
+    """Abstract base class for storage adapters.
+
+    All storage backends (local, network, cloud) implement this interface.
+    """
+
+    @abstractmethod
+    async def test_connection(self) -> bool:
+        """Verify connectivity and credentials."""
+        ...
+
+    @abstractmethod
+    async def list_files(self, path: str = "") -> list[FileInfo]:
+        """List files and directories at path."""
+        ...
+
+    @abstractmethod
+    async def read_file(self, path: str) -> bytes:
+        """Read file contents."""
+        ...
+
+    @abstractmethod
+    async def write_file(self, path: str, data: bytes) -> None:
+        """Write data to file, creating directories as needed."""
+        ...
+
+    @abstractmethod
+    async def delete_file(self, path: str) -> None:
+        """Delete a file."""
+        ...
+
+    @abstractmethod
+    async def exists(self, path: str) -> bool:
+        """Check if file or directory exists."""
+        ...
+
+    @abstractmethod
+    async def get_file_info(self, path: str) -> FileInfo:
+        """Get metadata for a single file."""
+        ...
+
+    @abstractmethod
+    async def ensure_directory(self, path: str) -> None:
+        """Create directory and parents if they don't exist."""
+        ...
+
+    async def stream_file(self, path: str, chunk_size: int = 8192) -> AsyncIterator[bytes]:
+        """Stream file contents in chunks. Default reads entire file."""
+        data = await self.read_file(path)
+        for i in range(0, len(data), chunk_size):
+            yield data[i:i + chunk_size]

--- a/packages/backend/storage/exceptions.py
+++ b/packages/backend/storage/exceptions.py
@@ -1,0 +1,27 @@
+# packages/backend/storage/exceptions.py
+"""Storage adapter exceptions."""
+
+
+class StorageError(Exception):
+    """Base storage error."""
+    pass
+
+
+class StorageUnavailableError(StorageError):
+    """Storage location is unreachable."""
+    pass
+
+
+class StorageAuthError(StorageError):
+    """Authentication failed or expired."""
+    pass
+
+
+class StorageNotFoundError(StorageError):
+    """File or directory not found."""
+    pass
+
+
+class StoragePermissionError(StorageError):
+    """Permission denied."""
+    pass

--- a/packages/backend/storage/factory.py
+++ b/packages/backend/storage/factory.py
@@ -1,0 +1,53 @@
+"""Storage adapter factory."""
+
+from persistence.models import StorageLocation
+from services.encryption import decrypt_config
+from storage.base import StorageAdapter
+from storage.adapters.local import LocalAdapter
+
+
+# Registry of adapter classes by (type, subtype)
+ADAPTER_REGISTRY: dict[tuple[str, str | None], type[StorageAdapter]] = {
+    ("local", None): LocalAdapter,
+}
+
+
+def get_adapter(location: StorageLocation) -> StorageAdapter:
+    """Get appropriate storage adapter for a location.
+
+    Args:
+        location: StorageLocation model instance.
+
+    Returns:
+        Configured StorageAdapter instance.
+
+    Raises:
+        ValueError: If storage type is not supported.
+    """
+    key = (location.type, location.subtype)
+
+    # Try exact match first
+    adapter_class = ADAPTER_REGISTRY.get(key)
+
+    # Fall back to type-only match
+    if adapter_class is None:
+        adapter_class = ADAPTER_REGISTRY.get((location.type, None))
+
+    if adapter_class is None:
+        raise ValueError(
+            f"Unknown storage type: {location.type}/{location.subtype}"
+        )
+
+    # Decrypt credentials before passing to adapter
+    config = decrypt_config(location.config or {})
+
+    return adapter_class(config)
+
+
+def register_adapter(
+    storage_type: str,
+    subtype: str | None,
+    adapter_class: type[StorageAdapter]
+) -> None:
+    """Register an adapter class for a storage type."""
+    ADAPTER_REGISTRY[(storage_type, subtype)] = adapter_class

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -19,7 +19,7 @@ os.environ["VERBATIM_DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 from api.main import app
 from persistence.database import get_db
 # Import all models to ensure their tables are created
-from persistence.models import Base, Project, Recording, Transcript, Segment, Speaker, Job, Setting
+from persistence.models import Base, Project, Recording, Transcript, Segment, Speaker, Job, Setting, StorageLocation
 
 
 # Create test database engine

--- a/packages/backend/tests/test_encryption.py
+++ b/packages/backend/tests/test_encryption.py
@@ -1,0 +1,52 @@
+"""Tests for credential encryption service."""
+
+import pytest
+from services.encryption import encrypt_config, decrypt_config, SENSITIVE_FIELDS
+
+
+def test_encrypt_decrypt_roundtrip():
+    """Encrypted config should decrypt back to original."""
+    original = {
+        "bucket": "my-bucket",
+        "region": "us-east-1",
+        "access_key": "AKIAIOSFODNN7EXAMPLE",
+        "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    }
+
+    encrypted = encrypt_config(original)
+
+    # Non-sensitive fields unchanged
+    assert encrypted["bucket"] == "my-bucket"
+    assert encrypted["region"] == "us-east-1"
+    assert encrypted["access_key"] == "AKIAIOSFODNN7EXAMPLE"
+
+    # Sensitive field is encrypted
+    assert "_encrypted" in encrypted["secret_key"]
+    assert encrypted["secret_key"]["_encrypted"] != original["secret_key"]
+
+    # Decrypt back
+    decrypted = decrypt_config(encrypted)
+    assert decrypted == original
+
+
+def test_encrypt_empty_config():
+    """Empty config should remain empty."""
+    assert encrypt_config({}) == {}
+    assert decrypt_config({}) == {}
+
+
+def test_encrypt_none_values():
+    """None values should be preserved."""
+    config = {"password": None, "username": "admin"}
+    encrypted = encrypt_config(config)
+    assert encrypted["password"] is None
+    assert encrypted["username"] == "admin"
+
+
+def test_sensitive_fields_list():
+    """Verify expected sensitive fields."""
+    expected = {
+        "password", "secret_key", "account_key", "connection_string",
+        "credentials_json", "oauth_tokens", "access_token", "refresh_token"
+    }
+    assert SENSITIVE_FIELDS == expected

--- a/packages/backend/tests/test_storage_factory.py
+++ b/packages/backend/tests/test_storage_factory.py
@@ -1,0 +1,31 @@
+# packages/backend/tests/test_storage_factory.py
+"""Tests for storage adapter factory."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from storage.factory import get_adapter
+from storage.adapters.local import LocalAdapter
+
+
+def test_get_local_adapter():
+    """Factory returns LocalAdapter for local type."""
+    location = MagicMock()
+    location.type = "local"
+    location.subtype = None
+    location.config = {"path": "/tmp/test"}
+
+    adapter = get_adapter(location)
+
+    assert isinstance(adapter, LocalAdapter)
+
+
+def test_get_adapter_unknown_type():
+    """Factory raises for unknown type."""
+    location = MagicMock()
+    location.type = "unknown"
+    location.subtype = None
+    location.config = {}
+
+    with pytest.raises(ValueError, match="Unknown storage type"):
+        get_adapter(location)

--- a/packages/backend/tests/test_storage_local.py
+++ b/packages/backend/tests/test_storage_local.py
@@ -1,0 +1,107 @@
+# packages/backend/tests/test_storage_local.py
+"""Tests for local storage adapter."""
+
+import pytest
+from pathlib import Path
+import tempfile
+import shutil
+
+from storage.adapters.local import LocalAdapter
+from storage.exceptions import StorageNotFoundError
+
+
+@pytest.fixture
+def temp_storage():
+    """Create a temporary directory for testing."""
+    path = Path(tempfile.mkdtemp())
+    yield path
+    shutil.rmtree(path)
+
+
+@pytest.fixture
+def adapter(temp_storage):
+    """Create a LocalAdapter for the temp directory."""
+    return LocalAdapter({"path": str(temp_storage)})
+
+
+@pytest.mark.asyncio
+async def test_test_connection(adapter, temp_storage):
+    """Test connection should succeed for valid path."""
+    assert await adapter.test_connection() is True
+
+
+@pytest.mark.asyncio
+async def test_test_connection_invalid_path():
+    """Test connection should fail for non-existent path."""
+    adapter = LocalAdapter({"path": "/nonexistent/path/12345"})
+    with pytest.raises(Exception):
+        await adapter.test_connection()
+
+
+@pytest.mark.asyncio
+async def test_write_and_read_file(adapter, temp_storage):
+    """Write then read file."""
+    await adapter.write_file("test.txt", b"hello world")
+    content = await adapter.read_file("test.txt")
+    assert content == b"hello world"
+    assert (temp_storage / "test.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_creates_directories(adapter, temp_storage):
+    """Write should create parent directories."""
+    await adapter.write_file("a/b/c/test.txt", b"nested")
+    assert (temp_storage / "a/b/c/test.txt").exists()
+    content = await adapter.read_file("a/b/c/test.txt")
+    assert content == b"nested"
+
+
+@pytest.mark.asyncio
+async def test_exists(adapter, temp_storage):
+    """Check file and directory existence."""
+    assert await adapter.exists("missing.txt") is False
+    await adapter.write_file("exists.txt", b"data")
+    assert await adapter.exists("exists.txt") is True
+    await adapter.ensure_directory("subdir")
+    assert await adapter.exists("subdir") is True
+
+
+@pytest.mark.asyncio
+async def test_delete_file(adapter, temp_storage):
+    """Delete a file."""
+    await adapter.write_file("to_delete.txt", b"bye")
+    assert await adapter.exists("to_delete.txt") is True
+    await adapter.delete_file("to_delete.txt")
+    assert await adapter.exists("to_delete.txt") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_raises(adapter):
+    """Delete non-existent file should raise."""
+    with pytest.raises(StorageNotFoundError):
+        await adapter.delete_file("nonexistent.txt")
+
+
+@pytest.mark.asyncio
+async def test_list_files(adapter, temp_storage):
+    """List files in directory."""
+    await adapter.write_file("file1.txt", b"a")
+    await adapter.write_file("file2.txt", b"b")
+    await adapter.ensure_directory("subdir")
+
+    files = await adapter.list_files("")
+    names = {f.name for f in files}
+
+    assert "file1.txt" in names
+    assert "file2.txt" in names
+    assert "subdir" in names
+
+
+@pytest.mark.asyncio
+async def test_get_file_info(adapter, temp_storage):
+    """Get info for specific file."""
+    await adapter.write_file("info_test.txt", b"test content")
+    info = await adapter.get_file_info("info_test.txt")
+    assert info.name == "info_test.txt"
+    assert info.size == 12
+    assert info.is_directory is False

--- a/packages/backend/tests/test_storage_locations_api.py
+++ b/packages/backend/tests/test_storage_locations_api.py
@@ -1,0 +1,124 @@
+# packages/backend/tests/test_storage_locations_api.py
+"""Tests for storage locations API endpoints.
+
+Note: The storage locations API uses direct async_session access rather than
+dependency injection, so database-related tests are limited. The /test endpoint
+tests work correctly as they don't require database access.
+"""
+
+import pytest
+import shutil
+import tempfile
+from pathlib import Path
+
+from httpx import AsyncClient
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory."""
+    path = Path(tempfile.mkdtemp())
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_test_connection_local_valid(client: AsyncClient, temp_dir: Path):
+    """Test connection should succeed for valid local path."""
+    response = await client.post("/api/storage-locations/test", json={
+        "type": "local",
+        "config": {"path": str(temp_dir)}
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["latency_ms"] is not None
+    assert data["latency_ms"] > 0
+
+
+@pytest.mark.asyncio
+async def test_test_connection_local_invalid(client: AsyncClient):
+    """Test connection should fail for invalid path."""
+    response = await client.post("/api/storage-locations/test", json={
+        "type": "local",
+        "config": {"path": "/nonexistent/path/xyz123"}
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    assert data["error"] is not None
+    assert "Cannot connect" in data["error"] or "not exist" in data["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_test_connection_unknown_type(client: AsyncClient):
+    """Test connection should fail for unknown type."""
+    response = await client.post("/api/storage-locations/test", json={
+        "type": "unknown_type",
+        "config": {}
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    assert "Unknown storage type" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_test_connection_with_subtype(client: AsyncClient, temp_dir: Path):
+    """Test connection should work with subtype specified."""
+    response = await client.post("/api/storage-locations/test", json={
+        "type": "local",
+        "subtype": None,
+        "config": {"path": str(temp_dir)}
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_test_connection_validates_all_config_fields(client: AsyncClient, temp_dir: Path):
+    """Test connection accepts all possible config fields without error."""
+    response = await client.post("/api/storage-locations/test", json={
+        "type": "local",
+        "config": {
+            "path": str(temp_dir),
+            # These fields are valid in schema but not used by local adapter
+            "server": None,
+            "share": None,
+            "bucket": None,
+        }
+    })
+    assert response.status_code == 200
+    data = response.json()
+    # Should still succeed since local adapter only needs path
+    assert data["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_test_connection_returns_latency(client: AsyncClient, temp_dir: Path):
+    """Test connection should return latency measurement."""
+    response = await client.post("/api/storage-locations/test", json={
+        "type": "local",
+        "config": {"path": str(temp_dir)}
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert "latency_ms" in data
+    # Latency should be a positive number when successful
+    assert isinstance(data["latency_ms"], (int, float))
+    assert data["latency_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_test_connection_no_latency_on_failure(client: AsyncClient):
+    """Test connection should not return latency on failure."""
+    response = await client.post("/api/storage-locations/test", json={
+        "type": "local",
+        "config": {"path": "/nonexistent/path/xyz123"}
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    # On failure, latency should be None
+    assert data["latency_ms"] is None

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,6 +15,7 @@
     "clsx": "^2.1.1",
     "docx-preview": "^0.3.7",
     "exceljs": "^4.4.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.469.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -25,6 +26,7 @@
     "wavesurfer.js": "^7.12.1"
   },
   "devDependencies": {
+    "@types/jszip": "^3.4.1",
     "@types/node": "^22.10.5",
     "@types/react": "^18.3.17",
     "@types/react-dom": "^18.3.5",

--- a/packages/frontend/src/components/storage/StorageConfigForm.tsx
+++ b/packages/frontend/src/components/storage/StorageConfigForm.tsx
@@ -1,0 +1,318 @@
+import type { StorageType, StorageSubtype, StorageLocationConfig } from '@/lib/api';
+
+interface StorageConfigFormProps {
+  storageType: StorageType;
+  subtype: StorageSubtype;
+  config: StorageLocationConfig;
+  onChange: (config: StorageLocationConfig) => void;
+}
+
+const inputClasses = "w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary";
+const labelClasses = "block text-sm font-medium text-foreground mb-1.5";
+const hintClasses = "text-xs text-muted-foreground mt-1";
+
+export function StorageConfigForm({ storageType, subtype, config, onChange }: StorageConfigFormProps) {
+  const updateField = (field: string, value: string) => {
+    onChange({ ...config, [field]: value || undefined });
+  };
+
+  // Local storage
+  if (storageType === 'local') {
+    return (
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="path" className={labelClasses}>Path</label>
+          <input
+            id="path"
+            type="text"
+            value={config.path || ''}
+            onChange={(e) => updateField('path', e.target.value)}
+            placeholder="/path/to/storage"
+            className={`${inputClasses} font-mono`}
+          />
+          <p className={hintClasses}>
+            Full path to a folder. It will be created if it doesn't exist.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // SMB
+  if (storageType === 'network' && subtype === 'smb') {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="server" className={labelClasses}>Server</label>
+            <input
+              id="server"
+              type="text"
+              value={config.server || ''}
+              onChange={(e) => updateField('server', e.target.value)}
+              placeholder="192.168.1.100 or nas.local"
+              className={inputClasses}
+            />
+          </div>
+          <div>
+            <label htmlFor="share" className={labelClasses}>Share Name</label>
+            <input
+              id="share"
+              type="text"
+              value={config.share || ''}
+              onChange={(e) => updateField('share', e.target.value)}
+              placeholder="media"
+              className={inputClasses}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="username" className={labelClasses}>Username</label>
+            <input
+              id="username"
+              type="text"
+              value={config.username || ''}
+              onChange={(e) => updateField('username', e.target.value)}
+              className={inputClasses}
+            />
+          </div>
+          <div>
+            <label htmlFor="password" className={labelClasses}>Password</label>
+            <input
+              id="password"
+              type="password"
+              value={config.password || ''}
+              onChange={(e) => updateField('password', e.target.value)}
+              className={inputClasses}
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="domain" className={labelClasses}>Domain (optional)</label>
+          <input
+            id="domain"
+            type="text"
+            value={config.domain || ''}
+            onChange={(e) => updateField('domain', e.target.value)}
+            placeholder="WORKGROUP"
+            className={inputClasses}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // NFS
+  if (storageType === 'network' && subtype === 'nfs') {
+    return (
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="server" className={labelClasses}>Server</label>
+          <input
+            id="server"
+            type="text"
+            value={config.server || ''}
+            onChange={(e) => updateField('server', e.target.value)}
+            placeholder="192.168.1.100"
+            className={inputClasses}
+          />
+        </div>
+        <div>
+          <label htmlFor="export_path" className={labelClasses}>Export Path</label>
+          <input
+            id="export_path"
+            type="text"
+            value={config.export_path || ''}
+            onChange={(e) => updateField('export_path', e.target.value)}
+            placeholder="/exports/media"
+            className={`${inputClasses} font-mono`}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // S3
+  if (storageType === 'cloud' && subtype === 's3') {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="bucket" className={labelClasses}>Bucket</label>
+            <input
+              id="bucket"
+              type="text"
+              value={config.bucket || ''}
+              onChange={(e) => updateField('bucket', e.target.value)}
+              placeholder="my-bucket"
+              className={inputClasses}
+            />
+          </div>
+          <div>
+            <label htmlFor="region" className={labelClasses}>Region</label>
+            <input
+              id="region"
+              type="text"
+              value={config.region || ''}
+              onChange={(e) => updateField('region', e.target.value)}
+              placeholder="us-east-1"
+              className={inputClasses}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="access_key" className={labelClasses}>Access Key</label>
+            <input
+              id="access_key"
+              type="text"
+              value={config.access_key || ''}
+              onChange={(e) => updateField('access_key', e.target.value)}
+              className={`${inputClasses} font-mono`}
+            />
+          </div>
+          <div>
+            <label htmlFor="secret_key" className={labelClasses}>Secret Key</label>
+            <input
+              id="secret_key"
+              type="password"
+              value={config.secret_key || ''}
+              onChange={(e) => updateField('secret_key', e.target.value)}
+              className={inputClasses}
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="endpoint" className={labelClasses}>Custom Endpoint (optional)</label>
+          <input
+            id="endpoint"
+            type="text"
+            value={config.endpoint || ''}
+            onChange={(e) => updateField('endpoint', e.target.value)}
+            placeholder="https://s3.us-west-001.backblazeb2.com"
+            className={inputClasses}
+          />
+          <p className={hintClasses}>
+            For Backblaze B2, Wasabi, MinIO, etc. Leave empty for AWS S3.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Azure
+  if (storageType === 'cloud' && subtype === 'azure') {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="account_name" className={labelClasses}>Account Name</label>
+            <input
+              id="account_name"
+              type="text"
+              value={config.account_name || ''}
+              onChange={(e) => updateField('account_name', e.target.value)}
+              className={inputClasses}
+            />
+          </div>
+          <div>
+            <label htmlFor="container" className={labelClasses}>Container</label>
+            <input
+              id="container"
+              type="text"
+              value={config.container || ''}
+              onChange={(e) => updateField('container', e.target.value)}
+              className={inputClasses}
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="account_key" className={labelClasses}>Account Key</label>
+          <input
+            id="account_key"
+            type="password"
+            value={config.account_key || ''}
+            onChange={(e) => updateField('account_key', e.target.value)}
+            className={inputClasses}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // GCS
+  if (storageType === 'cloud' && subtype === 'gcs') {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="bucket" className={labelClasses}>Bucket</label>
+            <input
+              id="bucket"
+              type="text"
+              value={config.bucket || ''}
+              onChange={(e) => updateField('bucket', e.target.value)}
+              className={inputClasses}
+            />
+          </div>
+          <div>
+            <label htmlFor="project_id" className={labelClasses}>Project ID</label>
+            <input
+              id="project_id"
+              type="text"
+              value={config.project_id || ''}
+              onChange={(e) => updateField('project_id', e.target.value)}
+              className={inputClasses}
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="credentials_json" className={labelClasses}>Service Account JSON</label>
+          <textarea
+            id="credentials_json"
+            value={config.credentials_json || ''}
+            onChange={(e) => updateField('credentials_json', e.target.value)}
+            placeholder='{"type": "service_account", ...}'
+            className="w-full h-32 rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary resize-none"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // OAuth providers placeholder
+  if (storageType === 'cloud' && ['gdrive', 'onedrive', 'dropbox'].includes(subtype || '')) {
+    return (
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="folder_path" className={labelClasses}>Folder Path (optional)</label>
+          <input
+            id="folder_path"
+            type="text"
+            value={config.folder_path || ''}
+            onChange={(e) => updateField('folder_path', e.target.value)}
+            placeholder="Verbatim Studio"
+            className={inputClasses}
+          />
+          <p className={hintClasses}>
+            Leave empty to use root folder.
+          </p>
+        </div>
+        <p className="text-sm text-amber-600 dark:text-amber-400">
+          Click "Connect" below to authenticate with {
+            subtype === 'gdrive' ? 'Google' :
+            subtype === 'onedrive' ? 'Microsoft' :
+            'Dropbox'
+          }.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-muted-foreground text-sm">
+      Select a storage type and provider to configure.
+    </div>
+  );
+}

--- a/packages/frontend/src/components/storage/StorageSubtypeSelector.tsx
+++ b/packages/frontend/src/components/storage/StorageSubtypeSelector.tsx
@@ -1,0 +1,61 @@
+import { cn } from '@/lib/utils';
+import type { StorageType, StorageSubtype } from '@/lib/api';
+
+interface StorageSubtypeSelectorProps {
+  storageType: StorageType;
+  value: StorageSubtype;
+  onChange: (subtype: StorageSubtype) => void;
+}
+
+const subtypes: Record<StorageType, { subtype: StorageSubtype; label: string; description: string }[]> = {
+  local: [],
+  network: [
+    { subtype: 'smb', label: 'SMB / Windows Share', description: 'Samba, Windows file sharing' },
+    { subtype: 'nfs', label: 'NFS', description: 'Network File System (Unix/Linux)' },
+  ],
+  cloud: [
+    { subtype: 's3', label: 'S3-Compatible', description: 'AWS S3, Backblaze B2, MinIO, Wasabi' },
+    { subtype: 'gdrive', label: 'Google Drive', description: 'Personal or Workspace account' },
+    { subtype: 'onedrive', label: 'OneDrive', description: 'Microsoft OneDrive' },
+    { subtype: 'dropbox', label: 'Dropbox', description: 'Dropbox cloud storage' },
+    { subtype: 'azure', label: 'Azure Blob', description: 'Microsoft Azure Blob Storage' },
+    { subtype: 'gcs', label: 'Google Cloud Storage', description: 'GCS bucket' },
+  ],
+};
+
+export function StorageSubtypeSelector({ storageType, value, onChange }: StorageSubtypeSelectorProps) {
+  const options = subtypes[storageType];
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+        Select Provider
+      </label>
+      <div className="grid grid-cols-2 gap-2">
+        {options.map(({ subtype, label, description }) => (
+          <button
+            key={subtype}
+            type="button"
+            onClick={() => onChange(subtype)}
+            className={cn(
+              'flex flex-col items-start p-3 rounded-lg border transition-all text-left',
+              'hover:border-primary hover:bg-primary/5',
+              value === subtype
+                ? 'border-primary bg-primary/10'
+                : 'border-gray-200 dark:border-gray-700'
+            )}
+          >
+            <span className="font-medium text-sm">{label}</span>
+            <span className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              {description}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/storage/StorageTypeSelector.tsx
+++ b/packages/frontend/src/components/storage/StorageTypeSelector.tsx
@@ -1,0 +1,61 @@
+import { HardDrive, Server, Cloud } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { StorageType } from '@/lib/api';
+
+interface StorageTypeSelectorProps {
+  value: StorageType;
+  onChange: (type: StorageType) => void;
+}
+
+const types: { type: StorageType; label: string; description: string; icon: React.ReactNode }[] = [
+  {
+    type: 'local',
+    label: 'Local Storage',
+    description: 'Folder on this computer',
+    icon: <HardDrive className="w-8 h-8" />,
+  },
+  {
+    type: 'network',
+    label: 'Network Storage',
+    description: 'SMB or NFS share',
+    icon: <Server className="w-8 h-8" />,
+  },
+  {
+    type: 'cloud',
+    label: 'Cloud Storage',
+    description: 'S3, Google Drive, etc.',
+    icon: <Cloud className="w-8 h-8" />,
+  },
+];
+
+export function StorageTypeSelector({ value, onChange }: StorageTypeSelectorProps) {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {types.map(({ type, label, description, icon }) => (
+        <button
+          key={type}
+          type="button"
+          onClick={() => onChange(type)}
+          className={cn(
+            'flex flex-col items-center p-4 rounded-lg border-2 transition-all',
+            'hover:border-primary hover:bg-primary/5',
+            value === type
+              ? 'border-primary bg-primary/10'
+              : 'border-gray-200 dark:border-gray-700'
+          )}
+        >
+          <div className={cn(
+            'mb-2',
+            value === type ? 'text-primary' : 'text-gray-500 dark:text-gray-400'
+          )}>
+            {icon}
+          </div>
+          <span className="font-medium text-sm">{label}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 text-center mt-1">
+            {description}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/settings/SettingsPage.tsx
+++ b/packages/frontend/src/pages/settings/SettingsPage.tsx
@@ -363,7 +363,7 @@ export function SettingsPage({ theme, onThemeChange }: SettingsPageProps) {
 
     try {
       // Start the migration
-      const status = await api.storageLocations.startMigration({
+      const status = await api.storageLocations.migrate({
         source_path: migrationSource,
         destination_path: migrationDest,
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,15 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      docx-preview:
+        specifier: ^0.3.7
+        version: 0.3.7
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@18.3.1)
@@ -50,13 +59,25 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.27)(react@18.3.1)
       react-router-dom:
         specifier: ^7.1.1
         version: 7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
+      wavesurfer.js:
+        specifier: ^7.12.1
+        version: 7.12.1
     devDependencies:
+      '@types/jszip':
+        specifier: ^3.4.1
+        version: 3.4.1
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.7
@@ -364,6 +385,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fast-csv/format@4.3.5':
+    resolution: {integrity: sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==}
+
+  '@fast-csv/parse@4.3.6':
+    resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
+
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
@@ -594,20 +621,36 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/http-cache-semantics@4.0.4':
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
+
+  '@types/jszip@3.4.1':
+    resolution: {integrity: sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==}
+    deprecated: This is a stub types definition. jszip provides its own type definitions, so you do not need this installed.
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@14.18.63':
+    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
   '@types/node@20.19.30':
     resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
@@ -632,11 +675,20 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -763,6 +815,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -773,15 +828,25 @@ packages:
     resolution: {integrity: sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==}
     hasBin: true
 
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  binary@0.3.0:
+    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   bluebird-lst@1.0.9:
     resolution: {integrity: sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
@@ -811,8 +876,16 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer-indexof-polyfill@1.0.2:
+    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
+    engines: {node: '>=0.10'}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffers@0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
 
   builder-util-runtime@9.2.10:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
@@ -844,9 +917,27 @@ packages:
   caniuse-lite@1.0.30001764:
     resolution: {integrity: sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chainsaw@0.1.0:
+    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -911,6 +1002,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -979,6 +1073,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -987,6 +1084,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1014,12 +1114,19 @@ packages:
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1039,6 +1146,9 @@ packages:
     os: [darwin]
     hasBin: true
 
+  docx-preview@0.3.7:
+    resolution: {integrity: sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==}
+
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
     engines: {node: '>=12'}
@@ -1050,6 +1160,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1129,8 +1242,22 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  exceljs@4.4.0:
+    resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
+    engines: {node: '>=8.3.0'}
+
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -1140,6 +1267,10 @@ packages:
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
+
+  fast-csv@4.3.6:
+    resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
+    engines: {node: '>=10.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1214,6 +1345,11 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fstream@1.0.12:
+    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
+    engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1305,9 +1441,18 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -1347,6 +1492,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1365,9 +1513,18 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1381,6 +1538,9 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1393,6 +1553,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
@@ -1403,6 +1566,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -1466,6 +1633,9 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1476,6 +1646,9 @@ packages:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
 
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -1483,20 +1656,48 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  listenercount@1.0.1:
+    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash.isfunction@3.0.9:
+    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
+
+  lodash.isnil@4.0.0:
+    resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
+  lodash.isundefined@3.0.1:
+    resolution: {integrity: sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==}
+
   lodash.union@4.6.0:
     resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
+
+  lodash.uniq@4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -1504,6 +1705,9 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1536,6 +1740,9 @@ packages:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -1544,9 +1751,138 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1630,6 +1966,10 @@ packages:
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -1724,6 +2064,12 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -1836,6 +2182,9 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -1854,6 +2203,12 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -1901,6 +2256,18 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -1931,6 +2298,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -1968,6 +2340,10 @@ packages:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
 
+  saxes@5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -1992,6 +2368,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2043,6 +2422,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -2068,6 +2450,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2075,6 +2460,12 @@ packages:
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -2138,9 +2529,18 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  traverse@0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
@@ -2163,6 +2563,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unique-filename@2.0.1:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -2171,6 +2574,21 @@ packages:
     resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -2178,6 +2596,9 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unzipper@0.10.14:
+    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2194,9 +2615,19 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -2238,6 +2669,9 @@ packages:
       yaml:
         optional: true
 
+  wavesurfer.js@7.12.1:
+    resolution: {integrity: sha512-NswPjVHxk0Q1F/VMRemCPUzSojjuHHisQrBqQiRXg7MVbe3f5vQ6r0rTTXA/a/neC/4hnOEC4YpXca4LpH0SUg==}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -2263,6 +2697,9 @@ packages:
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2292,6 +2729,9 @@ packages:
   zip-stream@4.1.1:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2565,6 +3005,25 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@fast-csv/format@4.3.5':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.isboolean: 3.0.3
+      lodash.isequal: 4.5.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+
+  '@fast-csv/parse@4.3.6':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.groupby: 4.6.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+      lodash.isundefined: 3.0.1
+      lodash.uniq: 4.5.0
+
   '@gar/promisify@1.1.3': {}
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -2763,19 +3222,37 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
 
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 22.19.7
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/http-cache-semantics@4.0.4': {}
+
+  '@types/jszip@3.4.1':
+    dependencies:
+      jszip: 3.10.1
 
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 22.19.7
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/ms@2.1.0': {}
+
+  '@types/node@14.18.63': {}
 
   '@types/node@20.19.30':
     dependencies:
@@ -2806,6 +3283,10 @@ snapshots:
     dependencies:
       '@types/node': 22.19.7
 
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
   '@types/verror@1.10.11':
     optional: true
 
@@ -2813,6 +3294,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.7
     optional: true
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.7)(jiti@1.21.7))':
     dependencies:
@@ -2987,13 +3470,22 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.15: {}
 
+  big-integer@1.6.52: {}
+
   binary-extensions@2.3.0: {}
+
+  binary@0.3.0:
+    dependencies:
+      buffers: 0.1.1
+      chainsaw: 0.1.0
 
   bl@4.1.0:
     dependencies:
@@ -3004,6 +3496,8 @@ snapshots:
   bluebird-lst@1.0.9:
     dependencies:
       bluebird: 3.7.2
+
+  bluebird@3.4.7: {}
 
   bluebird@3.7.2: {}
 
@@ -3035,10 +3529,14 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer-indexof-polyfill@1.0.2: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buffers@0.1.1: {}
 
   builder-util-runtime@9.2.10:
     dependencies:
@@ -3112,10 +3610,24 @@ snapshots:
 
   caniuse-lite@1.0.30001764: {}
 
+  ccount@2.0.1: {}
+
+  chainsaw@0.1.0:
+    dependencies:
+      traverse: 0.3.9
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -3179,6 +3691,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  comma-separated-tokens@2.0.3: {}
+
   commander@4.1.1: {}
 
   commander@5.1.0: {}
@@ -3241,9 +3755,15 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  dayjs@1.11.19: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   decompress-response@6.0.0:
     dependencies:
@@ -3273,10 +3793,16 @@ snapshots:
 
   delegates@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-node@2.1.0:
     optional: true
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   didyoumean@1.2.2: {}
 
@@ -3314,6 +3840,10 @@ snapshots:
       verror: 1.10.1
     optional: true
 
+  docx-preview@0.3.7:
+    dependencies:
+      jszip: 3.10.1
+
   dotenv-expand@11.0.7:
     dependencies:
       dotenv: 16.6.1
@@ -3325,6 +3855,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
 
   eastasianwidth@0.2.0: {}
 
@@ -3451,7 +3985,25 @@ snapshots:
   escape-string-regexp@4.0.0:
     optional: true
 
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  exceljs@4.4.0:
+    dependencies:
+      archiver: 5.3.2
+      dayjs: 1.11.19
+      fast-csv: 4.3.6
+      jszip: 3.10.1
+      readable-stream: 3.6.2
+      saxes: 5.0.1
+      tmp: 0.2.5
+      unzipper: 0.10.14
+      uuid: 8.3.2
+
   exponential-backoff@3.1.3: {}
+
+  extend@3.0.2: {}
 
   extract-zip@2.0.1:
     dependencies:
@@ -3465,6 +4017,11 @@ snapshots:
 
   extsprintf@1.4.1:
     optional: true
+
+  fast-csv@4.3.6:
+    dependencies:
+      '@fast-csv/format': 4.3.5
+      '@fast-csv/parse': 4.3.6
 
   fast-deep-equal@3.1.3: {}
 
@@ -3548,6 +4105,13 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  fstream@1.0.12:
+    dependencies:
+      graceful-fs: 4.2.11
+      inherits: 2.0.4
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
 
   function-bind@1.1.2: {}
 
@@ -3675,9 +4239,35 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
+
+  html-url-attributes@3.0.1: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -3731,6 +4321,8 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  immediate@3.0.6: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -3744,7 +4336,16 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   ip-address@10.1.0: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3758,6 +4359,8 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -3766,11 +4369,15 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@1.0.0: {}
 
   is-lambda@1.0.1: {}
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-unicode-supported@0.1.0: {}
 
@@ -3823,6 +4430,13 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3833,19 +4447,41 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  listenercount@1.0.1: {}
 
   lodash.defaults@4.2.0: {}
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
+
+  lodash.groupby@4.6.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
+
+  lodash.isfunction@3.0.9: {}
+
+  lodash.isnil@4.0.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
+  lodash.isundefined@3.0.1: {}
+
   lodash.union@4.6.0: {}
+
+  lodash.uniq@4.5.0: {}
 
   lodash@4.17.21: {}
 
@@ -3853,6 +4489,8 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -3898,6 +4536,8 @@ snapshots:
       - bluebird
       - supports-color
 
+  markdown-table@3.0.4: {}
+
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
@@ -3905,7 +4545,351 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -3980,6 +4964,10 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
 
   mkdirp@1.0.4: {}
 
@@ -4079,6 +5067,18 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -4158,6 +5158,8 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
+  property-information@7.1.0: {}
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -4174,6 +5176,24 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-markdown@10.1.0(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.27
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-refresh@0.17.0: {}
 
@@ -4229,6 +5249,40 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
   require-directory@2.1.1: {}
 
   resedit@1.7.2:
@@ -4255,6 +5309,10 @@ snapshots:
   retry@0.12.0: {}
 
   reusify@1.1.0: {}
+
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
 
   rimraf@3.0.2:
     dependencies:
@@ -4321,6 +5379,10 @@ snapshots:
 
   sax@1.4.4: {}
 
+  saxes@5.0.1:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -4340,6 +5402,8 @@ snapshots:
   set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.2: {}
+
+  setimmediate@1.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4388,6 +5452,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -4417,6 +5483,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4424,6 +5495,14 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   sucrase@3.35.1:
     dependencies:
@@ -4526,7 +5605,13 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  traverse@0.3.9: {}
+
   tree-kill@1.2.2: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   truncate-utf8-bytes@1.0.2:
     dependencies:
@@ -4543,6 +5628,16 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unique-filename@2.0.1:
     dependencies:
       unique-slug: 3.0.0
@@ -4551,9 +5646,45 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unzipper@0.10.14:
+    dependencies:
+      big-integer: 1.6.52
+      binary: 0.3.0
+      bluebird: 3.4.7
+      buffer-indexof-polyfill: 1.0.2
+      duplexer2: 0.1.4
+      fstream: 1.0.12
+      graceful-fs: 4.2.11
+      listenercount: 1.0.1
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -4569,12 +5700,24 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@8.3.2: {}
+
   verror@1.10.1:
     dependencies:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.4.1
     optional: true
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@6.4.1(@types/node@22.19.7)(jiti@1.21.7):
     dependencies:
@@ -4588,6 +5731,8 @@ snapshots:
       '@types/node': 22.19.7
       fsevents: 2.3.3
       jiti: 1.21.7
+
+  wavesurfer.js@7.12.1: {}
 
   wcwidth@1.0.1:
     dependencies:
@@ -4616,6 +5761,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 
@@ -4647,3 +5794,5 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Add storage type selection supporting local, network (SMB/NFS), and cloud providers (S3, Azure, GCS, Google Drive, OneDrive, Dropbox)
- Add credential encryption with Fernet + OS keychain storage
- Add storage adapter pattern with LocalAdapter implementation
- Add frontend components for storage type/subtype selection and configuration

## Phase 1 Foundation (this PR)
- Database migration for subtype/status columns
- Encryption service for secure credential storage
- Abstract StorageAdapter interface
- LocalAdapter with path traversal protection
- Adapter factory with registry pattern
- API routes with test connection endpoint
- Frontend TypeScript types
- StorageTypeSelector, StorageSubtypeSelector, StorageConfigForm components

## Test Plan
- [x] LocalAdapter tests passing
- [x] Encryption service tests passing
- [x] Factory tests passing
- [x] API endpoint tests passing
- [x] TypeScript compilation passing
- [ ] Manual Playwright testing of UI

Closes #76

🤖 Generated with [Claude Code](https://claude.ai/code)