### PR TITLE
feat: add automatic update checking with release notes dialog (#96)

### DIFF
--- a/apps/electron/package-lock.json
+++ b/apps/electron/package-lock.json
@@ -1,0 +1,541 @@
+{
+  "name": "@verbatim/electron",
+  "version": "0.26.22",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@verbatim/electron",
+      "version": "0.26.22",
+      "dependencies": {
+        "electron-store": "^8.2.0",
+        "electron-updater": "^6.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.5",
+        "concurrently": "^9.1.2",
+        "electron": "^34.0.0",
+        "electron-builder": "^25.1.8",
+        "typescript": "^5.7.2"
+      }
+    },
+    "../../node_modules/.pnpm/@types+node@22.19.7/node_modules/@types/node": {
+      "version": "22.19.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "../../node_modules/.pnpm/concurrently@9.2.1/node_modules/concurrently": {
+      "version": "9.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.33.0",
+        "@hirez_io/observer-spy": "^2.2.0",
+        "@types/node": "^18.19.123",
+        "@types/shell-quote": "^1.7.5",
+        "@types/supports-color": "^8.1.3",
+        "@types/yargs": "^17.0.33",
+        "@vitest/coverage-v8": "^3.2.4",
+        "@vitest/eslint-plugin": "^1.3.4",
+        "coveralls-next": "^5.0.0",
+        "ctrlc-wrapper": "^0.0.5",
+        "esbuild": "~0.25.9",
+        "eslint": "^9.33.0",
+        "eslint-config-flat-gitignore": "^2.1.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-import-lite": "^0.3.0",
+        "eslint-plugin-prettier": "^5.5.4",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
+        "globals": "16.3.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.5.2",
+        "prettier": "^3.6.2",
+        "safe-publish-latest": "^2.0.0",
+        "string-argv": "^0.3.2",
+        "typescript": "~5.9.2",
+        "typescript-eslint": "^8.40.0",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "../../node_modules/.pnpm/electron-builder@25.1.8_electron-builder-squirrel-windows@25.1.8/node_modules/electron-builder": {
+      "version": "25.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "dmg-builder": "25.1.8",
+        "fs-extra": "^10.1.0",
+        "is-ci": "^3.0.0",
+        "lazy-val": "^1.0.5",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "devDependencies": {
+        "@types/fs-extra": "9.0.13",
+        "@types/is-ci": "3.0.0",
+        "@types/yargs": "^17.0.16"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/electron-updater@6.7.3/node_modules/electron-updater": {
+      "version": "6.7.3",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      },
+      "devDependencies": {
+        "@types/fs-extra": "9.0.13",
+        "@types/js-yaml": "4.0.3",
+        "@types/lodash.escaperegexp": "4.1.6",
+        "@types/lodash.isequal": "4.5.5",
+        "@types/semver": "7.7.1",
+        "electron": "35.7.5"
+      }
+    },
+    "../../node_modules/.pnpm/electron@34.5.8/node_modules/electron": {
+      "version": "34.5.8",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "devDependencies": {
+        "@dprint/formatter": "^0.4.1",
+        "@dprint/typescript": "0.93.4",
+        "@esfx/canceltoken": "^1.0.0",
+        "@eslint/js": "^9.20.0",
+        "@octokit/rest": "^21.1.1",
+        "@types/chai": "^4.3.20",
+        "@types/diff": "^7.0.1",
+        "@types/minimist": "^1.2.5",
+        "@types/mocha": "^10.0.10",
+        "@types/ms": "^0.7.34",
+        "@types/node": "latest",
+        "@types/source-map-support": "^0.5.10",
+        "@types/which": "^3.0.4",
+        "@typescript-eslint/rule-tester": "^8.24.1",
+        "@typescript-eslint/type-utils": "^8.24.1",
+        "@typescript-eslint/utils": "^8.24.1",
+        "azure-devops-node-api": "^14.1.0",
+        "c8": "^10.1.3",
+        "chai": "^4.5.0",
+        "chokidar": "^4.0.3",
+        "diff": "^7.0.0",
+        "dprint": "^0.49.0",
+        "esbuild": "^0.25.0",
+        "eslint": "^9.20.1",
+        "eslint-formatter-autolinkable-stylish": "^1.4.0",
+        "eslint-plugin-regexp": "^2.7.0",
+        "fast-xml-parser": "^4.5.2",
+        "glob": "^10.4.5",
+        "globals": "^15.15.0",
+        "hereby": "^1.10.0",
+        "jsonc-parser": "^3.3.1",
+        "knip": "^5.44.4",
+        "minimist": "^1.2.8",
+        "mocha": "^10.8.2",
+        "mocha-fivemat-progress-reporter": "^0.1.0",
+        "monocart-coverage-reports": "^2.12.1",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "playwright": "^1.50.1",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.24.1",
+        "which": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@types/node": {
+      "resolved": "../../node_modules/.pnpm/@types+node@22.19.7/node_modules/@types/node",
+      "link": true
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/concurrently": {
+      "resolved": "../../node_modules/.pnpm/concurrently@9.2.1/node_modules/concurrently",
+      "link": true
+    },
+    "node_modules/conf": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.1",
+        "json-schema-typed": "^7.0.3",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron": {
+      "resolved": "../../node_modules/.pnpm/electron@34.5.8/node_modules/electron",
+      "link": true
+    },
+    "node_modules/electron-builder": {
+      "resolved": "../../node_modules/.pnpm/electron-builder@25.1.8_electron-builder-squirrel-windows@25.1.8/node_modules/electron-builder",
+      "link": true
+    },
+    "node_modules/electron-store": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.2.0.tgz",
+      "integrity": "sha512-ukLL5Bevdil6oieAOXz3CMy+OgaItMiVBg701MNlG6W5RaC0AHN7rvlqTCmeb6O7jP0Qa1KKYTE0xV0xbhF4Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "conf": "^10.2.0",
+        "type-fest": "^2.17.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-updater": {
+      "resolved": "../../node_modules/.pnpm/electron-updater@6.7.3/node_modules/electron-updater",
+      "link": true
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "resolved": "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript",
+      "link": true
+    }
+  }
+}

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -16,6 +16,7 @@
     "prepare-resources": "../../scripts/prepare-electron-resources.sh"
   },
   "dependencies": {
+    "electron-store": "^8.2.0",
     "electron-updater": "^6.3.0"
   },
   "devDependencies": {
@@ -39,17 +40,23 @@
       {
         "from": "../../build/resources/python",
         "to": "python",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "../../build/resources/backend",
         "to": "backend",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "../../packages/frontend/dist",
         "to": "frontend",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "../../scripts/requirements-ml.txt",
@@ -58,7 +65,9 @@
       {
         "from": "../../build/resources/ffmpeg",
         "to": "ffmpeg",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       }
     ],
     "mac": {
@@ -67,7 +76,9 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["arm64"]
+          "arch": [
+            "arm64"
+          ]
         }
       ],
       "hardenedRuntime": true,
@@ -80,7 +91,9 @@
       "target": [
         {
           "target": "nsis",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ]
     },
@@ -89,7 +102,9 @@
       "target": [
         {
           "target": "AppImage",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "category": "Office"

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -76,6 +76,18 @@ export function registerIpcHandlers(): void {
 
   // Update handlers
   ipcMain.on('update:start', (_event, { downloadUrl, version }) => {
+    // Validate URL
+    try {
+      new URL(downloadUrl);
+    } catch {
+      console.error('[IPC] Invalid download URL:', downloadUrl);
+      return;
+    }
+    // Validate version
+    if (!version || typeof version !== 'string') {
+      console.error('[IPC] Invalid version:', version);
+      return;
+    }
     startUpdate(downloadUrl, version);
   });
 
@@ -84,6 +96,10 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.on('update:whats-new-seen', (_event, version) => {
+    if (!version || typeof version !== 'string') {
+      console.error('[IPC] Invalid version for whats-new-seen:', version);
+      return;
+    }
     markWhatsNewSeen(version);
   });
 
@@ -92,6 +108,10 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle('update:setAutoUpdate', (_event, enabled: boolean) => {
+    if (typeof enabled !== 'boolean') {
+      console.error('[IPC] Invalid enabled value:', enabled);
+      return;
+    }
     setAutoUpdateEnabled(enabled);
   });
 }

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1,5 +1,7 @@
 import { ipcMain, app, BrowserWindow, dialog } from 'electron';
 import { backendManager } from './backend';
+import { checkForUpdates, startUpdate, markWhatsNewSeen } from './updater';
+import { getAutoUpdateEnabled, setAutoUpdateEnabled } from './update-store';
 
 export function registerIpcHandlers(): void {
   // App info
@@ -70,5 +72,26 @@ export function registerIpcHandlers(): void {
   ipcMain.on('window:close', (event) => {
     const window = BrowserWindow.fromWebContents(event.sender);
     window?.close();
+  });
+
+  // Update handlers
+  ipcMain.on('update:start', (_event, { downloadUrl, version }) => {
+    startUpdate(downloadUrl, version);
+  });
+
+  ipcMain.on('update:check', () => {
+    checkForUpdates(true); // manual = true
+  });
+
+  ipcMain.on('update:whats-new-seen', (_event, version) => {
+    markWhatsNewSeen(version);
+  });
+
+  ipcMain.handle('update:getSettings', () => {
+    return { autoUpdateEnabled: getAutoUpdateEnabled() };
+  });
+
+  ipcMain.handle('update:setAutoUpdate', (_event, enabled: boolean) => {
+    setAutoUpdateEnabled(enabled);
   });
 }

--- a/apps/electron/src/main/update-script.ts
+++ b/apps/electron/src/main/update-script.ts
@@ -1,0 +1,161 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export const UPDATE_DIR = '/tmp/verbatim-update';
+
+/**
+ * Generates a shell script for seamless macOS app replacement.
+ * The script:
+ * 1. Waits for the app to quit (with timeout)
+ * 2. Removes old app from /Applications
+ * 3. Copies new app from mounted DMG volume
+ * 4. Relaunches the app
+ * 5. Cleans up (unmounts DMG, removes temp files)
+ */
+export function generateUpdaterScript(volumePath: string, appName: string): string {
+  const appPath = `/Applications/${appName}.app`;
+  const sourceAppPath = `${volumePath}/${appName}.app`;
+  const maxWaitSeconds = 30;
+
+  return `#!/bin/bash
+set -e
+
+APP_NAME="${appName}"
+APP_PATH="${appPath}"
+SOURCE_APP="${sourceAppPath}"
+VOLUME_PATH="${volumePath}"
+UPDATE_DIR="${UPDATE_DIR}"
+MAX_WAIT=${maxWaitSeconds}
+WAIT_COUNT=0
+
+# Function to show macOS notification
+notify() {
+  osascript -e "display notification \\"$1\\" with title \\"$APP_NAME Update\\""
+}
+
+# Function to show error and exit
+fail() {
+  notify "$1"
+  echo "ERROR: $1" >&2
+  cleanup
+  exit 1
+}
+
+# Function to cleanup
+cleanup() {
+  # Unmount DMG if mounted
+  if [ -d "$VOLUME_PATH" ]; then
+    hdiutil detach "$VOLUME_PATH" -quiet 2>/dev/null || true
+  fi
+
+  # Remove temp update directory
+  if [ -d "$UPDATE_DIR" ]; then
+    rm -rf "$UPDATE_DIR" 2>/dev/null || true
+  fi
+}
+
+# Wait for the app to quit
+echo "Waiting for $APP_NAME to quit..."
+while pgrep -x "$APP_NAME" > /dev/null; do
+  sleep 1
+  WAIT_COUNT=$((WAIT_COUNT + 1))
+  if [ $WAIT_COUNT -ge $MAX_WAIT ]; then
+    fail "Timed out waiting for $APP_NAME to quit. Please close the app and try again."
+  fi
+done
+
+echo "$APP_NAME has quit. Proceeding with update..."
+
+# Verify source app exists
+if [ ! -d "$SOURCE_APP" ]; then
+  fail "Update source not found at $SOURCE_APP"
+fi
+
+# Remove old app
+echo "Removing old version..."
+if [ -d "$APP_PATH" ]; then
+  rm -rf "$APP_PATH" || fail "Failed to remove old version. Check permissions."
+fi
+
+# Copy new app
+echo "Installing new version..."
+cp -R "$SOURCE_APP" "$APP_PATH" || fail "Failed to copy new version. Check disk space and permissions."
+
+# Remove quarantine attribute (for unsigned apps)
+xattr -rd com.apple.quarantine "$APP_PATH" 2>/dev/null || true
+
+# Verify installation
+if [ ! -d "$APP_PATH" ]; then
+  fail "Installation verification failed"
+fi
+
+echo "Update installed successfully!"
+
+# Cleanup before relaunch
+cleanup
+
+# Relaunch the app
+echo "Relaunching $APP_NAME..."
+open "$APP_PATH"
+
+exit 0
+`;
+}
+
+/**
+ * Writes the updater script to disk and sets executable permissions.
+ * @param volumePath - The mounted DMG volume path (e.g., "/Volumes/Verbatim Studio")
+ * @param appName - The application name (e.g., "Verbatim Studio")
+ * @returns The path to the written script
+ */
+export async function writeUpdaterScript(volumePath: string, appName: string): Promise<string> {
+  // Ensure update directory exists
+  await fs.mkdir(UPDATE_DIR, { recursive: true });
+
+  const scriptContent = generateUpdaterScript(volumePath, appName);
+  const scriptPath = path.join(UPDATE_DIR, 'update.sh');
+
+  // Write the script
+  await fs.writeFile(scriptPath, scriptContent, 'utf-8');
+
+  // Set executable permission (0o755 = rwxr-xr-x)
+  await fs.chmod(scriptPath, 0o755);
+
+  return scriptPath;
+}
+
+/**
+ * Parses hdiutil attach output to extract the volume mount path.
+ * Example output format:
+ *   /dev/disk4s1  Apple_HFS  /Volumes/Verbatim Studio
+ *   /dev/disk4              /Volumes/Verbatim Studio
+ * @param hdiutilOutput - The stdout from hdiutil attach command
+ * @returns The extracted volume path
+ * @throws Error if volume path cannot be found
+ */
+export async function parseVolumePath(hdiutilOutput: string): Promise<string> {
+  // Split into lines and process each
+  const lines = hdiutilOutput.trim().split('\n');
+
+  for (const line of lines) {
+    // Look for lines containing /Volumes/
+    const volumeMatch = line.match(/\/Volumes\/[^\t\n]+/);
+    if (volumeMatch) {
+      // Trim any trailing whitespace
+      return volumeMatch[0].trim();
+    }
+  }
+
+  // Alternative parsing: some hdiutil outputs use tabs
+  for (const line of lines) {
+    const parts = line.split('\t');
+    for (const part of parts) {
+      const trimmed = part.trim();
+      if (trimmed.startsWith('/Volumes/')) {
+        return trimmed;
+      }
+    }
+  }
+
+  throw new Error('Volume path not found in hdiutil output. Output was: ' + hdiutilOutput);
+}

--- a/apps/electron/src/main/update-store.ts
+++ b/apps/electron/src/main/update-store.ts
@@ -1,0 +1,40 @@
+import Store from 'electron-store';
+
+interface UpdateStoreSchema {
+  autoUpdateEnabled: boolean;
+  lastUpdateCheck: number;
+  lastSeenVersion: string;
+}
+
+export const updateStore = new Store<UpdateStoreSchema>({
+  name: 'update-preferences',
+  defaults: {
+    autoUpdateEnabled: true,
+    lastUpdateCheck: 0,
+    lastSeenVersion: '',
+  },
+});
+
+export function getAutoUpdateEnabled(): boolean {
+  return updateStore.get('autoUpdateEnabled');
+}
+
+export function setAutoUpdateEnabled(enabled: boolean): void {
+  updateStore.set('autoUpdateEnabled', enabled);
+}
+
+export function getLastUpdateCheck(): number {
+  return updateStore.get('lastUpdateCheck');
+}
+
+export function setLastUpdateCheck(timestamp: number): void {
+  updateStore.set('lastUpdateCheck', timestamp);
+}
+
+export function getLastSeenVersion(): string {
+  return updateStore.get('lastSeenVersion');
+}
+
+export function setLastSeenVersion(version: string): void {
+  updateStore.set('lastSeenVersion', version);
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -36,32 +36,38 @@ try {
   onUpdateAvailable: (
     callback: (data: { version: string; downloadUrl: string }) => void
   ) => {
-    ipcRenderer.on('update-available', (_event, data) => callback(data));
-    return () => ipcRenderer.removeAllListeners('update-available');
+    const handler = (_event: Electron.IpcRendererEvent, data: { version: string; downloadUrl: string }) => callback(data);
+    ipcRenderer.on('update-available', handler);
+    return () => ipcRenderer.off('update-available', handler);
   },
   onUpdateNotAvailable: (callback: () => void) => {
-    ipcRenderer.on('update-not-available', () => callback());
-    return () => ipcRenderer.removeAllListeners('update-not-available');
+    const handler = () => callback();
+    ipcRenderer.on('update-not-available', handler);
+    return () => ipcRenderer.off('update-not-available', handler);
   },
   onUpdateDownloading: (callback: (data: { percent: number }) => void) => {
-    ipcRenderer.on('update-downloading', (_event, data) => callback(data));
-    return () => ipcRenderer.removeAllListeners('update-downloading');
+    const handler = (_event: Electron.IpcRendererEvent, data: { percent: number }) => callback(data);
+    ipcRenderer.on('update-downloading', handler);
+    return () => ipcRenderer.off('update-downloading', handler);
   },
   onUpdateReady: (callback: (data: { version: string }) => void) => {
-    ipcRenderer.on('update-ready', (_event, data) => callback(data));
-    return () => ipcRenderer.removeAllListeners('update-ready');
+    const handler = (_event: Electron.IpcRendererEvent, data: { version: string }) => callback(data);
+    ipcRenderer.on('update-ready', handler);
+    return () => ipcRenderer.off('update-ready', handler);
   },
   onUpdateError: (
     callback: (data: { message: string; fallbackUrl?: string }) => void
   ) => {
-    ipcRenderer.on('update-error', (_event, data) => callback(data));
-    return () => ipcRenderer.removeAllListeners('update-error');
+    const handler = (_event: Electron.IpcRendererEvent, data: { message: string; fallbackUrl?: string }) => callback(data);
+    ipcRenderer.on('update-error', handler);
+    return () => ipcRenderer.off('update-error', handler);
   },
   onShowWhatsNew: (
     callback: (data: { releases: Array<{ version: string; notes: string }> }) => void
   ) => {
-    ipcRenderer.on('show-whats-new', (_event, data) => callback(data));
-    return () => ipcRenderer.removeAllListeners('show-whats-new');
+    const handler = (_event: Electron.IpcRendererEvent, data: { releases: Array<{ version: string; notes: string }> }) => callback(data);
+    ipcRenderer.on('show-whats-new', handler);
+    return () => ipcRenderer.off('show-whats-new', handler);
   },
 
   // Update actions

--- a/docs/plans/2026-02-04-auto-update-implementation.md
+++ b/docs/plans/2026-02-04-auto-update-implementation.md
@@ -1,0 +1,1316 @@
+# Auto-Update Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement seamless auto-update for the Electron app with "What's New" dialog on first launch after update.
+
+**Architecture:** Custom GitHub-based updater that downloads DMG, removes quarantine, mounts, and uses a shell script handoff to replace the app while it quits and relaunches. Release notes shown on first launch of new version via electron-store tracking.
+
+**Tech Stack:** Electron (main process), electron-store, GitHub Releases API, React (frontend dialogs), execFile for safe command execution.
+
+---
+
+## Task 1: Create electron-store for Update Preferences
+
+**Files:**
+- Create: `apps/electron/src/main/update-store.ts`
+
+**Step 1: Write the update store module**
+
+```typescript
+// apps/electron/src/main/update-store.ts
+import Store from 'electron-store';
+
+interface UpdateStoreSchema {
+  autoUpdateEnabled: boolean;
+  lastUpdateCheck: number;
+  lastSeenVersion: string;
+}
+
+const updateStore = new Store<UpdateStoreSchema>({
+  name: 'update-preferences',
+  defaults: {
+    autoUpdateEnabled: true,
+    lastUpdateCheck: 0,
+    lastSeenVersion: '',
+  },
+});
+
+export function getAutoUpdateEnabled(): boolean {
+  return updateStore.get('autoUpdateEnabled');
+}
+
+export function setAutoUpdateEnabled(enabled: boolean): void {
+  updateStore.set('autoUpdateEnabled', enabled);
+}
+
+export function getLastUpdateCheck(): number {
+  return updateStore.get('lastUpdateCheck');
+}
+
+export function setLastUpdateCheck(timestamp: number): void {
+  updateStore.set('lastUpdateCheck', timestamp);
+}
+
+export function getLastSeenVersion(): string {
+  return updateStore.get('lastSeenVersion');
+}
+
+export function setLastSeenVersion(version: string): void {
+  updateStore.set('lastSeenVersion', version);
+}
+
+export { updateStore };
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cd apps/electron && npm run build`
+Expected: No TypeScript errors
+
+**Step 3: Commit**
+
+```bash
+git add apps/electron/src/main/update-store.ts
+git commit -m "feat(updater): add electron-store for update preferences"
+```
+
+---
+
+## Task 2: Create Update Script Generator
+
+**Files:**
+- Create: `apps/electron/src/main/update-script.ts`
+
+**Step 1: Write the script generator**
+
+```typescript
+// apps/electron/src/main/update-script.ts
+import { writeFile } from 'fs/promises';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+
+const execFileAsync = promisify(execFile);
+
+const UPDATE_DIR = '/tmp/verbatim-update';
+
+export function generateUpdaterScript(volumePath: string, appName: string): string {
+  const appPath = `/Applications/${appName}.app`;
+
+  return `#!/bin/bash
+# Verbatim Studio Auto-Updater Script
+# Generated automatically - do not edit
+
+APP_NAME="${appName}"
+VOLUME_PATH="${volumePath}"
+APP_PATH="${appPath}"
+
+echo "[Updater] Waiting for app to quit..."
+
+# Wait for app to quit (max 30 seconds)
+TIMEOUT=30
+COUNTER=0
+while pgrep -x "$APP_NAME" > /dev/null; do
+  sleep 0.5
+  COUNTER=$((COUNTER + 1))
+  if [ $COUNTER -ge $((TIMEOUT * 2)) ]; then
+    echo "[Updater] Timeout waiting for app to quit"
+    osascript -e 'display notification "Update failed: App did not quit" with title "Verbatim Studio"'
+    hdiutil detach "$VOLUME_PATH" -quiet 2>/dev/null
+    exit 1
+  fi
+done
+
+echo "[Updater] App quit, replacing..."
+
+# Remove old app
+rm -rf "$APP_PATH"
+if [ $? -ne 0 ]; then
+  echo "[Updater] Failed to remove old app"
+  osascript -e 'display notification "Update failed: Could not remove old app" with title "Verbatim Studio"'
+  hdiutil detach "$VOLUME_PATH" -quiet 2>/dev/null
+  exit 1
+fi
+
+# Copy new app
+cp -R "$VOLUME_PATH/$APP_NAME.app" "/Applications/"
+if [ $? -ne 0 ]; then
+  echo "[Updater] Failed to copy new app"
+  osascript -e 'display notification "Update failed: Could not copy new app" with title "Verbatim Studio"'
+  hdiutil detach "$VOLUME_PATH" -quiet 2>/dev/null
+  exit 1
+fi
+
+echo "[Updater] Launching new version..."
+
+# Launch new version
+open "$APP_PATH"
+
+# Cleanup
+echo "[Updater] Cleaning up..."
+hdiutil detach "$VOLUME_PATH" -quiet 2>/dev/null
+rm -rf "${UPDATE_DIR}"
+
+echo "[Updater] Update complete!"
+`;
+}
+
+export async function writeUpdaterScript(volumePath: string, appName: string): Promise<string> {
+  const scriptPath = path.join(UPDATE_DIR, 'update.sh');
+  const script = generateUpdaterScript(volumePath, appName);
+
+  await writeFile(scriptPath, script, { mode: 0o755 });
+
+  return scriptPath;
+}
+
+export async function parseVolumePath(hdiutilOutput: string): Promise<string> {
+  // hdiutil output format: "/dev/disk4s1  Apple_HFS  /Volumes/Verbatim Studio"
+  const lines = hdiutilOutput.trim().split('\n');
+  for (const line of lines) {
+    const match = line.match(/\/Volumes\/.+$/);
+    if (match) {
+      return match[0];
+    }
+  }
+  throw new Error('Could not parse volume path from hdiutil output');
+}
+
+export { UPDATE_DIR };
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cd apps/electron && npm run build`
+Expected: No TypeScript errors
+
+**Step 3: Commit**
+
+```bash
+git add apps/electron/src/main/update-script.ts
+git commit -m "feat(updater): add shell script generator for seamless updates"
+```
+
+---
+
+## Task 3: Rewrite Updater Module
+
+**Files:**
+- Modify: `apps/electron/src/main/updater.ts` (complete rewrite)
+
+**Step 1: Rewrite the updater**
+
+```typescript
+// apps/electron/src/main/updater.ts
+import { app, BrowserWindow } from 'electron';
+import { execFile, spawn } from 'child_process';
+import { promisify } from 'util';
+import { createWriteStream } from 'fs';
+import { mkdir, rm } from 'fs/promises';
+import path from 'path';
+import https from 'https';
+import {
+  getAutoUpdateEnabled,
+  getLastUpdateCheck,
+  setLastUpdateCheck,
+  getLastSeenVersion,
+  setLastSeenVersion,
+} from './update-store';
+import { writeUpdaterScript, parseVolumePath, UPDATE_DIR } from './update-script';
+
+const execFileAsync = promisify(execFile);
+
+const GITHUB_OWNER = 'JongoDB';
+const GITHUB_REPO = 'verbatim-studio';
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const APP_NAME = 'Verbatim Studio';
+
+interface GitHubRelease {
+  tag_name: string;
+  name: string;
+  body: string;
+  published_at: string;
+  assets: GitHubAsset[];
+}
+
+interface GitHubAsset {
+  name: string;
+  browser_download_url: string;
+  size: number;
+}
+
+interface UpdateInfo {
+  version: string;
+  downloadUrl: string;
+  releaseNotes: string;
+  publishedAt: string;
+}
+
+let mainWindow: BrowserWindow | null = null;
+
+export function initAutoUpdater(window: BrowserWindow): void {
+  mainWindow = window;
+
+  if (!app.isPackaged) {
+    console.log('[Updater] Skipping updates in development mode');
+    return;
+  }
+
+  // Check for "What's New" on startup
+  checkWhatsNew();
+
+  // Check for updates on startup (after short delay)
+  setTimeout(() => {
+    if (getAutoUpdateEnabled()) {
+      checkForUpdates(false);
+    }
+  }, 5000);
+
+  // Schedule periodic checks
+  setInterval(() => {
+    if (getAutoUpdateEnabled() && shouldCheckForUpdates()) {
+      checkForUpdates(false);
+    }
+  }, 60 * 60 * 1000); // Check every hour if 24h has passed
+}
+
+function shouldCheckForUpdates(): boolean {
+  const lastCheck = getLastUpdateCheck();
+  const now = Date.now();
+  return now - lastCheck >= CHECK_INTERVAL_MS;
+}
+
+async function checkWhatsNew(): Promise<void> {
+  const currentVersion = app.getVersion();
+  const lastSeenVersion = getLastSeenVersion();
+
+  // First run or same version - nothing to show
+  if (!lastSeenVersion) {
+    setLastSeenVersion(currentVersion);
+    return;
+  }
+
+  if (lastSeenVersion === currentVersion) {
+    return;
+  }
+
+  // Version changed - fetch release notes for versions between last seen and current
+  console.log(`[Updater] Version changed: ${lastSeenVersion} -> ${currentVersion}`);
+
+  try {
+    const releases = await fetchReleaseNotes(lastSeenVersion, currentVersion);
+    if (releases.length > 0 && mainWindow) {
+      mainWindow.webContents.send('show-whats-new', { releases });
+    }
+  } catch (err) {
+    console.error('[Updater] Failed to fetch release notes:', err);
+  }
+}
+
+async function fetchReleaseNotes(
+  fromVersion: string,
+  toVersion: string
+): Promise<Array<{ version: string; notes: string }>> {
+  const releases = await fetchGitHubReleases();
+  const result: Array<{ version: string; notes: string }> = [];
+
+  const fromNum = parseVersion(fromVersion);
+  const toNum = parseVersion(toVersion);
+
+  for (const release of releases) {
+    const releaseVersion = release.tag_name.replace(/^v/, '');
+    const releaseNum = parseVersion(releaseVersion);
+
+    if (releaseNum > fromNum && releaseNum <= toNum) {
+      result.push({
+        version: releaseVersion,
+        notes: release.body || 'No release notes available.',
+      });
+    }
+  }
+
+  // Sort newest first
+  result.sort((a, b) => parseVersion(b.version) - parseVersion(a.version));
+  return result;
+}
+
+function parseVersion(version: string): number {
+  const parts = version.replace(/^v/, '').split('.').map(Number);
+  return parts[0] * 10000 + (parts[1] || 0) * 100 + (parts[2] || 0);
+}
+
+async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.github.com',
+      path: `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases`,
+      headers: {
+        'User-Agent': `${APP_NAME}/${app.getVersion()}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    };
+
+    https.get(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+export async function checkForUpdates(manual = false): Promise<void> {
+  if (!app.isPackaged && !manual) {
+    console.log('[Updater] Skipping updates in development mode');
+    return;
+  }
+
+  console.log('[Updater] Checking for updates...');
+  setLastUpdateCheck(Date.now());
+
+  try {
+    const releases = await fetchGitHubReleases();
+    if (releases.length === 0) {
+      if (manual && mainWindow) {
+        mainWindow.webContents.send('update-not-available');
+      }
+      return;
+    }
+
+    const latest = releases[0];
+    const latestVersion = latest.tag_name.replace(/^v/, '');
+    const currentVersion = app.getVersion();
+
+    if (parseVersion(latestVersion) <= parseVersion(currentVersion)) {
+      console.log('[Updater] Already on latest version');
+      if (manual && mainWindow) {
+        mainWindow.webContents.send('update-not-available');
+      }
+      return;
+    }
+
+    // Find the correct DMG for this architecture
+    const arch = process.arch; // 'arm64' or 'x64'
+    const asset = latest.assets.find(
+      (a) => a.name.includes(arch) && a.name.endsWith('.dmg')
+    );
+
+    if (!asset) {
+      console.error('[Updater] No DMG found for architecture:', arch);
+      if (mainWindow) {
+        mainWindow.webContents.send('update-error', {
+          message: `No update available for your system (${arch})`,
+        });
+      }
+      return;
+    }
+
+    console.log(`[Updater] Update available: ${currentVersion} -> ${latestVersion}`);
+
+    if (mainWindow) {
+      mainWindow.webContents.send('update-available', {
+        version: latestVersion,
+        downloadUrl: asset.browser_download_url,
+      });
+    }
+  } catch (err) {
+    console.error('[Updater] Error checking for updates:', err);
+    if (manual && mainWindow) {
+      mainWindow.webContents.send('update-error', {
+        message: 'Failed to check for updates. Please try again later.',
+      });
+    }
+  }
+}
+
+export async function startUpdate(downloadUrl: string, version: string): Promise<void> {
+  if (!mainWindow) return;
+
+  console.log(`[Updater] Starting update to ${version}...`);
+
+  try {
+    // Create temp directory
+    await mkdir(UPDATE_DIR, { recursive: true });
+
+    const dmgPath = path.join(UPDATE_DIR, `${APP_NAME}-${version}.dmg`);
+
+    // Download DMG
+    console.log('[Updater] Downloading...');
+    await downloadFile(downloadUrl, dmgPath, (percent) => {
+      mainWindow?.webContents.send('update-downloading', { percent });
+    });
+
+    // Remove quarantine
+    console.log('[Updater] Removing quarantine...');
+    await execFileAsync('xattr', ['-c', dmgPath]);
+
+    // Mount DMG
+    console.log('[Updater] Mounting DMG...');
+    const { stdout } = await execFileAsync('hdiutil', ['attach', '-nobrowse', dmgPath]);
+    const volumePath = await parseVolumePath(stdout);
+
+    console.log('[Updater] Volume mounted at:', volumePath);
+
+    // Generate and write updater script
+    const scriptPath = await writeUpdaterScript(volumePath, APP_NAME);
+
+    console.log('[Updater] Update ready, handing off to script...');
+    mainWindow.webContents.send('update-ready', { version });
+
+    // Spawn detached updater script
+    const child = spawn(scriptPath, [], {
+      detached: true,
+      stdio: 'ignore',
+      shell: true,
+    });
+    child.unref();
+
+    // Quit app to let script take over
+    setTimeout(() => {
+      app.quit();
+    }, 500);
+  } catch (err) {
+    console.error('[Updater] Update failed:', err);
+
+    // Cleanup on failure
+    try {
+      await rm(UPDATE_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    if (mainWindow) {
+      mainWindow.webContents.send('update-error', {
+        message: err instanceof Error ? err.message : 'Update failed',
+        fallbackUrl: `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`,
+      });
+    }
+  }
+}
+
+function downloadFile(
+  url: string,
+  destPath: string,
+  onProgress: (percent: number) => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const file = createWriteStream(destPath);
+
+    const request = https.get(url, (response) => {
+      // Handle redirects
+      if (response.statusCode === 302 || response.statusCode === 301) {
+        const redirectUrl = response.headers.location;
+        if (redirectUrl) {
+          file.close();
+          downloadFile(redirectUrl, destPath, onProgress).then(resolve).catch(reject);
+          return;
+        }
+      }
+
+      if (response.statusCode !== 200) {
+        file.close();
+        reject(new Error(`Download failed with status ${response.statusCode}`));
+        return;
+      }
+
+      const totalSize = parseInt(response.headers['content-length'] || '0', 10);
+      let downloadedSize = 0;
+
+      response.on('data', (chunk) => {
+        downloadedSize += chunk.length;
+        if (totalSize > 0) {
+          onProgress(Math.round((downloadedSize / totalSize) * 100));
+        }
+      });
+
+      response.pipe(file);
+
+      file.on('finish', () => {
+        file.close();
+        resolve();
+      });
+    });
+
+    request.on('error', (err) => {
+      file.close();
+      reject(err);
+    });
+  });
+}
+
+export function markWhatsNewSeen(version: string): void {
+  setLastSeenVersion(version);
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cd apps/electron && npm run build`
+Expected: No TypeScript errors
+
+**Step 3: Commit**
+
+```bash
+git add apps/electron/src/main/updater.ts
+git commit -m "feat(updater): rewrite with GitHub-based seamless updates"
+```
+
+---
+
+## Task 4: Add IPC Channels to Preload
+
+**Files:**
+- Modify: `apps/electron/src/preload/index.ts`
+
+**Step 1: Add update-related IPC channels**
+
+Add to the `contextBridge.exposeInMainWorld('electronAPI', {...})` object:
+
+```typescript
+// Update channels
+onUpdateAvailable: (callback: (data: { version: string; downloadUrl: string }) => void) => {
+  ipcRenderer.on('update-available', (_event, data) => callback(data));
+  return () => ipcRenderer.removeAllListeners('update-available');
+},
+onUpdateNotAvailable: (callback: () => void) => {
+  ipcRenderer.on('update-not-available', () => callback());
+  return () => ipcRenderer.removeAllListeners('update-not-available');
+},
+onUpdateDownloading: (callback: (data: { percent: number }) => void) => {
+  ipcRenderer.on('update-downloading', (_event, data) => callback(data));
+  return () => ipcRenderer.removeAllListeners('update-downloading');
+},
+onUpdateReady: (callback: (data: { version: string }) => void) => {
+  ipcRenderer.on('update-ready', (_event, data) => callback(data));
+  return () => ipcRenderer.removeAllListeners('update-ready');
+},
+onUpdateError: (callback: (data: { message: string; fallbackUrl?: string }) => void) => {
+  ipcRenderer.on('update-error', (_event, data) => callback(data));
+  return () => ipcRenderer.removeAllListeners('update-error');
+},
+onShowWhatsNew: (callback: (data: { releases: Array<{ version: string; notes: string }> }) => void) => {
+  ipcRenderer.on('show-whats-new', (_event, data) => callback(data));
+  return () => ipcRenderer.removeAllListeners('show-whats-new');
+},
+startUpdate: (downloadUrl: string, version: string): void => {
+  ipcRenderer.send('update:start', { downloadUrl, version });
+},
+checkForUpdates: (): void => {
+  ipcRenderer.send('update:check');
+},
+whatsNewSeen: (version: string): void => {
+  ipcRenderer.send('update:whats-new-seen', version);
+},
+getUpdateSettings: (): Promise<{ autoUpdateEnabled: boolean }> => {
+  return ipcRenderer.invoke('update:getSettings');
+},
+setAutoUpdate: (enabled: boolean): Promise<void> => {
+  return ipcRenderer.invoke('update:setAutoUpdate', enabled);
+},
+```
+
+**Step 2: Update the Window type declaration**
+
+Add to the `electronAPI` interface in the `declare global` section:
+
+```typescript
+// Update methods
+onUpdateAvailable: (callback: (data: { version: string; downloadUrl: string }) => void) => () => void;
+onUpdateNotAvailable: (callback: () => void) => () => void;
+onUpdateDownloading: (callback: (data: { percent: number }) => void) => () => void;
+onUpdateReady: (callback: (data: { version: string }) => void) => () => void;
+onUpdateError: (callback: (data: { message: string; fallbackUrl?: string }) => void) => () => void;
+onShowWhatsNew: (callback: (data: { releases: Array<{ version: string; notes: string }> }) => void) => () => void;
+startUpdate: (downloadUrl: string, version: string) => void;
+checkForUpdates: () => void;
+whatsNewSeen: (version: string) => void;
+getUpdateSettings: () => Promise<{ autoUpdateEnabled: boolean }>;
+setAutoUpdate: (enabled: boolean) => Promise<void>;
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cd apps/electron && npm run build`
+Expected: No TypeScript errors
+
+**Step 4: Commit**
+
+```bash
+git add apps/electron/src/preload/index.ts
+git commit -m "feat(updater): add IPC channels for update communication"
+```
+
+---
+
+## Task 5: Add IPC Handlers to Main Process
+
+**Files:**
+- Modify: `apps/electron/src/main/ipc.ts`
+
+**Step 1: Import updater functions**
+
+Add at top of file:
+
+```typescript
+import { checkForUpdates, startUpdate, markWhatsNewSeen } from './updater';
+import { getAutoUpdateEnabled, setAutoUpdateEnabled } from './update-store';
+```
+
+**Step 2: Add handlers in registerIpcHandlers function**
+
+Add these handlers:
+
+```typescript
+// Update handlers
+ipcMain.on('update:start', (_event, { downloadUrl, version }) => {
+  startUpdate(downloadUrl, version);
+});
+
+ipcMain.on('update:check', () => {
+  checkForUpdates(true);
+});
+
+ipcMain.on('update:whats-new-seen', (_event, version) => {
+  markWhatsNewSeen(version);
+});
+
+ipcMain.handle('update:getSettings', () => {
+  return { autoUpdateEnabled: getAutoUpdateEnabled() };
+});
+
+ipcMain.handle('update:setAutoUpdate', (_event, enabled: boolean) => {
+  setAutoUpdateEnabled(enabled);
+});
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cd apps/electron && npm run build`
+Expected: No TypeScript errors
+
+**Step 4: Commit**
+
+```bash
+git add apps/electron/src/main/ipc.ts
+git commit -m "feat(updater): add IPC handlers for update operations"
+```
+
+---
+
+## Task 6: Create UpdatePrompt Component
+
+**Files:**
+- Create: `packages/frontend/src/components/updates/UpdatePrompt.tsx`
+
+**Step 1: Create the component directory and file**
+
+```typescript
+// packages/frontend/src/components/updates/UpdatePrompt.tsx
+import { useState } from 'react';
+
+interface UpdatePromptProps {
+  version: string;
+  downloadUrl: string;
+  onUpdate: () => void;
+  onDismiss: () => void;
+}
+
+export function UpdatePrompt({ version, downloadUrl, onUpdate, onDismiss }: UpdatePromptProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [downloadPercent, setDownloadPercent] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [fallbackUrl, setFallbackUrl] = useState<string | null>(null);
+
+  // Listen for download progress
+  useState(() => {
+    if (!window.electronAPI) return;
+
+    const cleanupDownloading = window.electronAPI.onUpdateDownloading(({ percent }) => {
+      setDownloadPercent(percent);
+    });
+
+    const cleanupReady = window.electronAPI.onUpdateReady(() => {
+      // App will quit momentarily
+    });
+
+    const cleanupError = window.electronAPI.onUpdateError(({ message, fallbackUrl: url }) => {
+      setIsDownloading(false);
+      setError(message);
+      if (url) setFallbackUrl(url);
+    });
+
+    return () => {
+      cleanupDownloading();
+      cleanupReady();
+      cleanupError();
+    };
+  });
+
+  const handleUpdate = () => {
+    if (!window.electronAPI) return;
+    setIsDownloading(true);
+    setError(null);
+    window.electronAPI.startUpdate(downloadUrl, version);
+    onUpdate();
+  };
+
+  if (error) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+            Update Failed
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            {error}
+          </p>
+          {fallbackUrl && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              You can{' '}
+              <a
+                href={fallbackUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                download the update manually
+              </a>
+              .
+            </p>
+          )}
+          <div className="flex justify-end">
+            <button
+              onClick={onDismiss}
+              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isDownloading) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            Downloading Update
+          </h2>
+          <div className="mb-2">
+            <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+              <div
+                className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                style={{ width: `${downloadPercent}%` }}
+              />
+            </div>
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
+            {downloadPercent}% complete
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          Update Available
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          Version {version} is available.
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onDismiss}
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+          >
+            Later
+          </button>
+          <button
+            onClick={handleUpdate}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg"
+          >
+            Update Now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cd packages/frontend && npm run build`
+Expected: No TypeScript errors
+
+**Step 3: Commit**
+
+```bash
+git add packages/frontend/src/components/updates/UpdatePrompt.tsx
+git commit -m "feat(updater): add UpdatePrompt modal component"
+```
+
+---
+
+## Task 7: Create WhatsNewDialog Component
+
+**Files:**
+- Create: `packages/frontend/src/components/updates/WhatsNewDialog.tsx`
+
+**Step 1: Create the component**
+
+```typescript
+// packages/frontend/src/components/updates/WhatsNewDialog.tsx
+
+interface Release {
+  version: string;
+  notes: string;
+}
+
+interface WhatsNewDialogProps {
+  releases: Release[];
+  onDismiss: () => void;
+}
+
+export function WhatsNewDialog({ releases, onDismiss }: WhatsNewDialogProps) {
+  const handleDismiss = () => {
+    if (window.electronAPI && releases.length > 0) {
+      // Mark the newest version as seen
+      window.electronAPI.whatsNewSeen(releases[0].version);
+    }
+    onDismiss();
+  };
+
+  // Simple markdown-to-HTML for release notes (handles basic formatting)
+  const formatNotes = (notes: string) => {
+    return notes
+      .split('\n')
+      .map((line, i) => {
+        // Headers
+        if (line.startsWith('### ')) {
+          return (
+            <h4 key={i} className="font-medium text-gray-900 dark:text-gray-100 mt-3 mb-1">
+              {line.slice(4)}
+            </h4>
+          );
+        }
+        if (line.startsWith('## ')) {
+          return (
+            <h3 key={i} className="font-semibold text-gray-900 dark:text-gray-100 mt-4 mb-2">
+              {line.slice(3)}
+            </h3>
+          );
+        }
+        // Bullet points
+        if (line.startsWith('- ') || line.startsWith('* ')) {
+          const text = line.slice(2);
+          // Bold text
+          const parts = text.split(/\*\*(.+?)\*\*/g);
+          return (
+            <li key={i} className="ml-4 text-gray-600 dark:text-gray-400">
+              {parts.map((part, j) =>
+                j % 2 === 1 ? (
+                  <strong key={j} className="text-gray-900 dark:text-gray-100">
+                    {part}
+                  </strong>
+                ) : (
+                  part
+                )
+              )}
+            </li>
+          );
+        }
+        // Empty lines
+        if (line.trim() === '') {
+          return <br key={i} />;
+        }
+        // Regular text
+        return (
+          <p key={i} className="text-gray-600 dark:text-gray-400">
+            {line}
+          </p>
+        );
+      });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            What's New
+          </h2>
+          <button
+            onClick={handleDismiss}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-6 py-4 overflow-y-auto flex-1">
+          {releases.map((release, index) => (
+            <div key={release.version} className={index > 0 ? 'mt-6 pt-6 border-t border-gray-200 dark:border-gray-700' : ''}>
+              <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                v{release.version}
+              </h3>
+              <div className="text-sm space-y-1">
+                {formatNotes(release.notes)}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+          <button
+            onClick={handleDismiss}
+            className="w-full px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg"
+          >
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 2: Create index export**
+
+```typescript
+// packages/frontend/src/components/updates/index.ts
+export { UpdatePrompt } from './UpdatePrompt';
+export { WhatsNewDialog } from './WhatsNewDialog';
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cd packages/frontend && npm run build`
+Expected: No TypeScript errors
+
+**Step 4: Commit**
+
+```bash
+git add packages/frontend/src/components/updates/
+git commit -m "feat(updater): add WhatsNewDialog component for release notes"
+```
+
+---
+
+## Task 8: Add Updates Section to Settings Page
+
+**Files:**
+- Modify: `packages/frontend/src/pages/settings/SettingsPage.tsx`
+
+**Step 1: Add state and effects for update settings**
+
+Add near the top of the component (after other useState calls):
+
+```typescript
+// Update settings state
+const [autoUpdateEnabled, setAutoUpdateEnabled] = useState(true);
+const [isCheckingForUpdates, setIsCheckingForUpdates] = useState(false);
+const [updateCheckResult, setUpdateCheckResult] = useState<'none' | 'available' | null>(null);
+
+// Load update settings on mount
+useEffect(() => {
+  if (window.electronAPI) {
+    window.electronAPI.getUpdateSettings().then(({ autoUpdateEnabled }) => {
+      setAutoUpdateEnabled(autoUpdateEnabled);
+    });
+
+    const cleanupNotAvailable = window.electronAPI.onUpdateNotAvailable(() => {
+      setIsCheckingForUpdates(false);
+      setUpdateCheckResult('none');
+      setTimeout(() => setUpdateCheckResult(null), 3000);
+    });
+
+    const cleanupAvailable = window.electronAPI.onUpdateAvailable(() => {
+      setIsCheckingForUpdates(false);
+      setUpdateCheckResult('available');
+    });
+
+    return () => {
+      cleanupNotAvailable();
+      cleanupAvailable();
+    };
+  }
+}, []);
+
+const handleAutoUpdateToggle = async (enabled: boolean) => {
+  setAutoUpdateEnabled(enabled);
+  if (window.electronAPI) {
+    await window.electronAPI.setAutoUpdate(enabled);
+  }
+};
+
+const handleCheckForUpdates = () => {
+  if (window.electronAPI) {
+    setIsCheckingForUpdates(true);
+    setUpdateCheckResult(null);
+    window.electronAPI.checkForUpdates();
+  }
+};
+```
+
+**Step 2: Add the Updates section UI**
+
+Add this section right before the "About Verbatim Studio" section in the General tab (around line 2786):
+
+```tsx
+{/* Updates Section - only show in Electron */}
+{window.electronAPI && (
+  <div className="mt-6 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+    <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+      <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">Updates</h2>
+    </div>
+    <div className="px-5 py-4 space-y-4">
+      {/* Version display */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-600 dark:text-gray-400">Current Version</span>
+        <span className="text-sm font-mono text-gray-900 dark:text-gray-100">
+          {APP_VERSION}
+        </span>
+      </div>
+
+      {/* Auto-update toggle */}
+      <div className="flex items-center justify-between">
+        <div>
+          <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+            Check for updates automatically
+          </span>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            Checks on launch and every 24 hours
+          </p>
+        </div>
+        <button
+          onClick={() => handleAutoUpdateToggle(!autoUpdateEnabled)}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+            autoUpdateEnabled ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
+          }`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              autoUpdateEnabled ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* Check for updates button */}
+      <div className="pt-2">
+        <button
+          onClick={handleCheckForUpdates}
+          disabled={isCheckingForUpdates}
+          className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isCheckingForUpdates ? (
+            <span className="flex items-center gap-2">
+              <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+              Checking...
+            </span>
+          ) : (
+            'Check for Updates'
+          )}
+        </button>
+        {updateCheckResult === 'none' && (
+          <p className="mt-2 text-sm text-green-600 dark:text-green-400">
+            You're on the latest version!
+          </p>
+        )}
+        {updateCheckResult === 'available' && (
+          <p className="mt-2 text-sm text-blue-600 dark:text-blue-400">
+            Update available! Check the notification.
+          </p>
+        )}
+      </div>
+    </div>
+  </div>
+)}
+```
+
+**Step 3: Import APP_VERSION at the top of the file**
+
+Add import:
+```typescript
+import { APP_VERSION } from '@/version';
+```
+
+**Step 4: Verify it compiles**
+
+Run: `cd packages/frontend && npm run build`
+Expected: No TypeScript errors
+
+**Step 5: Commit**
+
+```bash
+git add packages/frontend/src/pages/settings/SettingsPage.tsx
+git commit -m "feat(updater): add Updates section to Settings page"
+```
+
+---
+
+## Task 9: Wire Up Dialogs in App.tsx
+
+**Files:**
+- Modify: `packages/frontend/src/app/App.tsx`
+
+**Step 1: Add imports**
+
+```typescript
+import { UpdatePrompt, WhatsNewDialog } from '@/components/updates';
+```
+
+**Step 2: Add state for update dialogs**
+
+Near the top of the App component, add:
+
+```typescript
+// Update dialog state
+const [updateInfo, setUpdateInfo] = useState<{ version: string; downloadUrl: string } | null>(null);
+const [whatsNewReleases, setWhatsNewReleases] = useState<Array<{ version: string; notes: string }> | null>(null);
+```
+
+**Step 3: Add effect to listen for update events**
+
+```typescript
+// Listen for update events from Electron
+useEffect(() => {
+  if (!window.electronAPI) return;
+
+  const cleanupAvailable = window.electronAPI.onUpdateAvailable((data) => {
+    setUpdateInfo(data);
+  });
+
+  const cleanupWhatsNew = window.electronAPI.onShowWhatsNew((data) => {
+    setWhatsNewReleases(data.releases);
+  });
+
+  return () => {
+    cleanupAvailable();
+    cleanupWhatsNew();
+  };
+}, []);
+```
+
+**Step 4: Add dialog components to the render**
+
+Add before the closing fragment or at the end of the component's return:
+
+```tsx
+{/* Update Prompt */}
+{updateInfo && (
+  <UpdatePrompt
+    version={updateInfo.version}
+    downloadUrl={updateInfo.downloadUrl}
+    onUpdate={() => {/* Download started, prompt handles rest */}}
+    onDismiss={() => setUpdateInfo(null)}
+  />
+)}
+
+{/* What's New Dialog */}
+{whatsNewReleases && whatsNewReleases.length > 0 && (
+  <WhatsNewDialog
+    releases={whatsNewReleases}
+    onDismiss={() => setWhatsNewReleases(null)}
+  />
+)}
+```
+
+**Step 5: Verify it compiles**
+
+Run: `cd packages/frontend && npm run build`
+Expected: No TypeScript errors
+
+**Step 6: Commit**
+
+```bash
+git add packages/frontend/src/app/App.tsx
+git commit -m "feat(updater): wire up UpdatePrompt and WhatsNewDialog in App"
+```
+
+---
+
+## Task 10: Final Integration Test
+
+**Step 1: Build the Electron app**
+
+```bash
+cd apps/electron && npm run build
+```
+
+Expected: No build errors
+
+**Step 2: Build the frontend**
+
+```bash
+cd packages/frontend && npm run build
+```
+
+Expected: No build errors
+
+**Step 3: Run lint checks**
+
+```bash
+npm run lint
+```
+
+Expected: No lint errors
+
+**Step 4: Commit any final fixes**
+
+If there are any TypeScript or lint errors, fix them and commit:
+
+```bash
+git add -A
+git commit -m "fix(updater): resolve build/lint issues"
+```
+
+**Step 5: Final commit for the feature**
+
+```bash
+git add -A
+git commit -m "feat: implement auto-update with release notes (#96)"
+```
+
+---
+
+## Summary
+
+This implementation provides:
+
+1. **Seamless auto-updates** for unsigned macOS apps via:
+   - GitHub Releases API for version checking
+   - DMG download with progress reporting
+   - Quarantine attribute removal (`xattr -c`)
+   - Shell script handoff for app replacement
+
+2. **What's New dialog** showing combined release notes on first launch after update
+
+3. **Settings integration** with:
+   - Version display
+   - Auto-update toggle
+   - Manual "Check for Updates" button
+
+4. **Error handling** with fallback to manual download link
+
+All communication happens via IPC channels between Electron main process and React frontend, with electron-store persisting user preferences.

--- a/packages/frontend/src/components/updates/UpdatePrompt.tsx
+++ b/packages/frontend/src/components/updates/UpdatePrompt.tsx
@@ -1,0 +1,272 @@
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface UpdatePromptProps {
+  version: string;
+  downloadUrl: string;
+  onUpdate: () => void;
+  onDismiss: () => void;
+}
+
+export function UpdatePrompt({
+  version,
+  downloadUrl,
+  onUpdate,
+  onDismiss,
+}: UpdatePromptProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [downloadPercent, setDownloadPercent] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [fallbackUrl, setFallbackUrl] = useState<string | null>(null);
+
+  // Set up IPC listeners for update progress
+  useEffect(() => {
+    if (!window.electronAPI) return;
+
+    const cleanupDownloading = window.electronAPI.onUpdateDownloading(
+      ({ percent }) => {
+        setDownloadPercent(percent);
+      }
+    );
+
+    const cleanupReady = window.electronAPI.onUpdateReady(() => {
+      // App will quit momentarily - no action needed
+    });
+
+    const cleanupError = window.electronAPI.onUpdateError(
+      ({ message, fallbackUrl: url }) => {
+        setIsDownloading(false);
+        setError(message);
+        if (url) setFallbackUrl(url);
+      }
+    );
+
+    return () => {
+      cleanupDownloading();
+      cleanupReady();
+      cleanupError();
+    };
+  }, []);
+
+  const handleUpdateNow = () => {
+    if (!window.electronAPI) return;
+
+    setIsDownloading(true);
+    setDownloadPercent(0);
+    setError(null);
+    setFallbackUrl(null);
+
+    window.electronAPI.startUpdate(downloadUrl, version);
+    onUpdate();
+  };
+
+  const handleClose = () => {
+    onDismiss();
+  };
+
+  // Render error state
+  if (error) {
+    return createPortal(
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        {/* Backdrop */}
+        <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+
+        {/* Modal */}
+        <div
+          className="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-xl shadow-2xl animate-in fade-in zoom-in-95 duration-200"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="update-error-title"
+        >
+          <div className="p-6">
+            {/* Error Icon */}
+            <div className="flex items-center justify-center w-12 h-12 mx-auto mb-4 rounded-full bg-red-100 dark:bg-red-900/30">
+              <svg
+                className="w-6 h-6 text-red-600 dark:text-red-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+            </div>
+
+            {/* Title */}
+            <h2
+              id="update-error-title"
+              className="text-lg font-semibold text-foreground text-center mb-2"
+            >
+              Update Failed
+            </h2>
+
+            {/* Error message */}
+            <p className="text-sm text-muted-foreground text-center mb-4">
+              {error}
+            </p>
+
+            {/* Fallback URL */}
+            {fallbackUrl && (
+              <p className="text-sm text-muted-foreground text-center mb-6">
+                You can download manually:{' '}
+                <a
+                  href={fallbackUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 dark:text-blue-400 underline hover:text-blue-500 dark:hover:text-blue-300"
+                >
+                  Download v{version}
+                </a>
+              </p>
+            )}
+
+            {/* Close button */}
+            <div className="flex justify-center">
+              <button
+                onClick={handleClose}
+                className="px-6 py-2.5 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>,
+      document.body
+    );
+  }
+
+  // Render downloading state
+  if (isDownloading) {
+    return createPortal(
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        {/* Backdrop */}
+        <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+
+        {/* Modal */}
+        <div
+          className="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-xl shadow-2xl animate-in fade-in zoom-in-95 duration-200"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="update-downloading-title"
+        >
+          <div className="p-6">
+            {/* Download Icon */}
+            <div className="flex items-center justify-center w-12 h-12 mx-auto mb-4 rounded-full bg-blue-100 dark:bg-blue-900/30">
+              <svg
+                className="w-6 h-6 text-blue-600 dark:text-blue-400 animate-pulse"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                />
+              </svg>
+            </div>
+
+            {/* Title */}
+            <h2
+              id="update-downloading-title"
+              className="text-lg font-semibold text-foreground text-center mb-4"
+            >
+              Downloading Update
+            </h2>
+
+            {/* Progress bar */}
+            <div className="mb-2">
+              <div className="h-2 bg-muted rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-blue-600 dark:bg-blue-500 transition-all duration-300 ease-out"
+                  style={{ width: `${downloadPercent}%` }}
+                />
+              </div>
+            </div>
+
+            {/* Percentage */}
+            <p className="text-sm text-muted-foreground text-center">
+              {Math.round(downloadPercent)}%
+            </p>
+          </div>
+        </div>
+      </div>,
+      document.body
+    );
+  }
+
+  // Render initial state (update available)
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+
+      {/* Modal */}
+      <div
+        className="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-xl shadow-2xl animate-in fade-in zoom-in-95 duration-200"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="update-available-title"
+        aria-describedby="update-available-description"
+      >
+        <div className="p-6">
+          {/* Update Icon */}
+          <div className="flex items-center justify-center w-12 h-12 mx-auto mb-4 rounded-full bg-green-100 dark:bg-green-900/30">
+            <svg
+              className="w-6 h-6 text-green-600 dark:text-green-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+          </div>
+
+          {/* Title */}
+          <h2
+            id="update-available-title"
+            className="text-lg font-semibold text-foreground text-center mb-2"
+          >
+            Update Available
+          </h2>
+
+          {/* Description */}
+          <p
+            id="update-available-description"
+            className="text-sm text-muted-foreground text-center mb-6"
+          >
+            Version {version} is available.
+          </p>
+
+          {/* Actions */}
+          <div className="flex items-center justify-center gap-4">
+            <button
+              onClick={handleClose}
+              className="px-6 py-2.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Later
+            </button>
+            <button
+              onClick={handleUpdateNow}
+              className="px-6 py-2.5 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+            >
+              Update Now
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/packages/frontend/src/components/updates/WhatsNewDialog.tsx
+++ b/packages/frontend/src/components/updates/WhatsNewDialog.tsx
@@ -89,9 +89,10 @@ function renderMarkdown(notes: string): React.ReactNode[] {
 
     // List item: - item or * item
     if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+      const content = trimmed.slice(2);
       listItems.push(
-        <li key={`li-${index}`} className="text-sm text-muted-foreground">
-          {renderBold(trimmed.slice(2))}
+        <li key={`${content.substring(0, 30)}-${index}`} className="text-sm text-muted-foreground">
+          {renderBold(content)}
         </li>
       );
       return;
@@ -120,8 +121,8 @@ export function WhatsNewDialog({ releases, onDismiss }: WhatsNewDialogProps) {
     onDismiss();
   };
 
-  const handleClose = () => {
-    handleGotIt();
+  const handleBackdropClick = () => {
+    onDismiss();
   };
 
   if (releases.length === 0) {
@@ -134,7 +135,7 @@ export function WhatsNewDialog({ releases, onDismiss }: WhatsNewDialogProps) {
       <div
         className="absolute inset-0 bg-black/50"
         aria-hidden="true"
-        onClick={handleClose}
+        onClick={handleBackdropClick}
       />
 
       {/* Modal */}
@@ -154,7 +155,7 @@ export function WhatsNewDialog({ releases, onDismiss }: WhatsNewDialogProps) {
             What's New
           </h2>
           <button
-            onClick={handleClose}
+            onClick={handleGotIt}
             className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
             aria-label="Close"
           >

--- a/packages/frontend/src/components/updates/WhatsNewDialog.tsx
+++ b/packages/frontend/src/components/updates/WhatsNewDialog.tsx
@@ -1,0 +1,211 @@
+import { createPortal } from 'react-dom';
+
+export interface Release {
+  version: string;
+  notes: string;
+}
+
+export interface WhatsNewDialogProps {
+  releases: Release[];
+  onDismiss: () => void;
+}
+
+/**
+ * Simple markdown renderer for release notes.
+ * Supports:
+ * - ### Header -> h4
+ * - ## Header -> h3
+ * - - item or * item -> list items
+ * - **text** -> bold
+ * - Empty lines -> br
+ */
+function renderMarkdown(notes: string): React.ReactNode[] {
+  const lines = notes.split('\n');
+  const elements: React.ReactNode[] = [];
+  let listItems: React.ReactNode[] = [];
+  let listKey = 0;
+
+  const flushList = () => {
+    if (listItems.length > 0) {
+      elements.push(
+        <ul key={`list-${listKey++}`} className="list-disc list-inside space-y-1 mb-3">
+          {listItems}
+        </ul>
+      );
+      listItems = [];
+    }
+  };
+
+  const renderBold = (text: string): React.ReactNode => {
+    const parts = text.split(/\*\*(.+?)\*\*/g);
+    return parts.map((part, i) =>
+      i % 2 === 1 ? (
+        <strong key={i} className="font-semibold">
+          {part}
+        </strong>
+      ) : (
+        part
+      )
+    );
+  };
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+
+    // Empty line
+    if (trimmed === '') {
+      flushList();
+      elements.push(<br key={`br-${index}`} />);
+      return;
+    }
+
+    // h3: ## Header
+    if (trimmed.startsWith('## ')) {
+      flushList();
+      elements.push(
+        <h3
+          key={`h3-${index}`}
+          className="text-base font-semibold text-foreground mb-2"
+        >
+          {renderBold(trimmed.slice(3))}
+        </h3>
+      );
+      return;
+    }
+
+    // h4: ### Header
+    if (trimmed.startsWith('### ')) {
+      flushList();
+      elements.push(
+        <h4
+          key={`h4-${index}`}
+          className="text-sm font-semibold text-foreground mb-2"
+        >
+          {renderBold(trimmed.slice(4))}
+        </h4>
+      );
+      return;
+    }
+
+    // List item: - item or * item
+    if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+      listItems.push(
+        <li key={`li-${index}`} className="text-sm text-muted-foreground">
+          {renderBold(trimmed.slice(2))}
+        </li>
+      );
+      return;
+    }
+
+    // Regular text
+    flushList();
+    elements.push(
+      <p key={`p-${index}`} className="text-sm text-muted-foreground mb-2">
+        {renderBold(trimmed)}
+      </p>
+    );
+  });
+
+  // Flush any remaining list items
+  flushList();
+
+  return elements;
+}
+
+export function WhatsNewDialog({ releases, onDismiss }: WhatsNewDialogProps) {
+  const handleGotIt = () => {
+    if (window.electronAPI && releases.length > 0) {
+      window.electronAPI.whatsNewSeen(releases[0].version);
+    }
+    onDismiss();
+  };
+
+  const handleClose = () => {
+    handleGotIt();
+  };
+
+  if (releases.length === 0) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        aria-hidden="true"
+        onClick={handleClose}
+      />
+
+      {/* Modal */}
+      <div
+        className="relative z-10 w-full max-w-lg mx-4 bg-card border border-border rounded-xl shadow-2xl animate-in fade-in zoom-in-95 duration-200 flex flex-col"
+        style={{ maxHeight: '80vh' }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="whats-new-title"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border shrink-0">
+          <h2
+            id="whats-new-title"
+            className="text-lg font-semibold text-foreground"
+          >
+            What's New
+          </h2>
+          <button
+            onClick={handleClose}
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            aria-label="Close"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {releases.map((release, index) => (
+            <div
+              key={release.version}
+              className={
+                index < releases.length - 1
+                  ? 'pb-4 mb-4 border-b border-border'
+                  : ''
+              }
+            >
+              <div className="text-sm font-medium text-foreground mb-2">
+                v{release.version}
+              </div>
+              <div>{renderMarkdown(release.notes)}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-border shrink-0">
+          <div className="flex justify-center">
+            <button
+              onClick={handleGotIt}
+              className="px-6 py-2.5 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+            >
+              Got it
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/packages/frontend/src/components/updates/index.ts
+++ b/packages/frontend/src/components/updates/index.ts
@@ -1,0 +1,2 @@
+export { UpdatePrompt } from './UpdatePrompt';
+export { WhatsNewDialog } from './WhatsNewDialog';

--- a/packages/frontend/src/types/electron.d.ts
+++ b/packages/frontend/src/types/electron.d.ts
@@ -17,6 +17,25 @@ interface ElectronAPI {
     filters?: { name: string; extensions: string[] }[];
     multiple?: boolean;
   }) => Promise<string | string[] | null>;
+
+  // Update methods
+  onUpdateAvailable: (
+    callback: (data: { version: string; downloadUrl: string }) => void
+  ) => () => void;
+  onUpdateNotAvailable: (callback: () => void) => () => void;
+  onUpdateDownloading: (callback: (data: { percent: number }) => void) => () => void;
+  onUpdateReady: (callback: (data: { version: string }) => void) => () => void;
+  onUpdateError: (
+    callback: (data: { message: string; fallbackUrl?: string }) => void
+  ) => () => void;
+  onShowWhatsNew: (
+    callback: (data: { releases: Array<{ version: string; notes: string }> }) => void
+  ) => () => void;
+  startUpdate: (downloadUrl: string, version: string) => void;
+  checkForUpdates: () => void;
+  whatsNewSeen: (version: string) => void;
+  getUpdateSettings: () => Promise<{ autoUpdateEnabled: boolean }>;
+  setAutoUpdate: (enabled: boolean) => Promise<void>;
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- Add seamless auto-update for unsigned macOS app (downloads DMG, removes quarantine, mounts, replaces app via shell script)
- Show "What's New" dialog on first launch after update with combined release notes
- Add Updates section to Settings with version display, auto-update toggle, and manual check button

## Implementation
- Custom GitHub-based updater replacing electron-updater (which doesn't work for unsigned apps)
- IPC communication between Electron main process and React frontend
- electron-store for persisting update preferences (auto-update enabled, last check time, last seen version)

## Security
- Input validation for app names and volume paths (prevents shell injection)
- Request timeouts (30s) and response size limits (5MB API, 500MB downloads)
- Redirect depth limit (max 5) to prevent infinite loops
- Partial download cleanup on errors

## Test Plan
- [ ] Build and run Electron app
- [ ] Check Settings > Updates section shows version and toggle
- [ ] Click "Check for Updates" button
- [ ] Verify update prompt appears when new version available
- [ ] Verify "What's New" dialog shows on first launch after manual version change

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #96