### PR TITLE
fix: add missing ai_summary migration and handle non-filesystem paths in archive

### DIFF
--- a/packages/backend/migrations/add_transcript_ai_summary.py
+++ b/packages/backend/migrations/add_transcript_ai_summary.py
@@ -1,0 +1,52 @@
+"""Add ai_summary column to transcripts table."""
+
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def migrate(db_path: Path) -> None:
+    """Add ai_summary JSON column to transcripts."""
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+
+        # Check if transcripts table exists
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='transcripts'"
+        )
+        if not cursor.fetchone():
+            logger.info("transcripts table does not exist yet - skipping migration")
+            conn.close()
+            return
+
+        # Check if column already exists
+        cursor.execute("PRAGMA table_info(transcripts)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        if "ai_summary" not in columns:
+            cursor.execute(
+                "ALTER TABLE transcripts ADD COLUMN ai_summary JSON DEFAULT NULL"
+            )
+            conn.commit()
+            logger.info("Added ai_summary column to transcripts")
+        else:
+            logger.debug("ai_summary column already exists")
+
+        conn.close()
+        logger.info("Transcript ai_summary migration complete")
+
+    except sqlite3.Error as e:
+        logger.error(f"Database error during transcript ai_summary migration: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error during transcript ai_summary migration: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    db_path = Path(__file__).parent.parent / "verbatim.db"
+    migrate(db_path)

--- a/packages/backend/persistence/database.py
+++ b/packages/backend/persistence/database.py
@@ -133,6 +133,10 @@ async def _run_migrations(conn) -> None:
     from migrations.add_storage_subtype import migrate as migrate_storage_subtype
     await conn.run_sync(lambda _: migrate_storage_subtype(db_path))
 
+    # Add ai_summary column to transcripts table
+    from migrations.add_transcript_ai_summary import migrate as migrate_transcript_ai_summary
+    await conn.run_sync(lambda _: migrate_transcript_ai_summary(db_path))
+
     # Add indexes on segments table for query performance
     from migrations.add_segment_indexes import migrate as migrate_segment_indexes
     await conn.run_sync(lambda _: migrate_segment_indexes(db_path))


### PR DESCRIPTION
## Summary
- Transcription was failing with `no such column: transcripts.ai_summary` for users upgrading from older versions — the column was added to the model but never got a startup migration
- `/api/archive/info` was returning 500 because it passed `live://` sentinel paths and cloud storage relative paths to `Path()`, causing unhandled exceptions
- `/api/archive/export` had the same issue when including media files

## Changes
- **New migration** (`add_transcript_ai_summary.py`): adds the `ai_summary` JSON column to `transcripts` on startup if missing
- **archive.py `/info` endpoint**: skip `live://` sentinel paths, fall back to DB `file_size` for cloud/relative paths, broaden exception handling
- **archive.py `/export` endpoint**: skip non-filesystem paths when packaging media files

## Test plan
- [ ] Fresh install works (create_all handles the column)
- [ ] Upgrade from pre-ai_summary version auto-migrates the column
- [ ] Live recording → transcription completes without error
- [ ] Upload recording → transcription completes without error
- [ ] `/api/archive/info` returns 200 with correct data
- [ ] Archive export works with mixed path types

🤖 Generated with [Claude Code](https://claude.com/claude-code)