### PR TITLE
fix: validate OCR model download includes processor files

### DIFF
--- a/packages/backend/api/routes/ocr.py
+++ b/packages/backend/api/routes/ocr.py
@@ -226,12 +226,15 @@ def _do_download_sync(model_id: str, repo: str, dest_path: Path, marker_file: Pa
         )
         logger.info("OCR model download complete: %s -> %s", model_id, result)
 
-        # Verify the model.safetensors file exists
+        # Verify essential model files exist (weights + processor config)
         safetensors_path = dest_path / "model.safetensors"
         if not safetensors_path.exists():
             raise RuntimeError(f"Download completed but model.safetensors not found at {safetensors_path}")
         logger.info("Verified model.safetensors exists: %s (%.2f GB)",
                     safetensors_path, safetensors_path.stat().st_size / 1e9)
+        preprocessor_path = dest_path / "preprocessor_config.json"
+        if not preprocessor_path.exists():
+            raise RuntimeError(f"Download completed but preprocessor_config.json not found at {preprocessor_path}")
     except Exception as exc:
         logger.exception("OCR model download failed: %s - %s", model_id, exc)
         # Clean up partial download on failure

--- a/packages/backend/core/ocr_catalog.py
+++ b/packages/backend/core/ocr_catalog.py
@@ -54,9 +54,10 @@ def is_model_downloaded(model_id: str) -> bool:
     if is_model_downloading(model_id):
         return False
 
-    # Check for key model files (safetensors or pytorch files)
-    model_files = list(path.glob("*.safetensors")) + list(path.glob("*.bin"))
-    return len(model_files) > 0
+    # Check for model weights AND processor files required by AutoProcessor
+    has_weights = list(path.glob("*.safetensors")) or list(path.glob("*.bin"))
+    has_processor = (path / "preprocessor_config.json").exists()
+    return bool(has_weights) and has_processor
 
 
 def get_model_size_on_disk(model_id: str) -> int | None:


### PR DESCRIPTION
## Summary
- OCR model download could appear complete while missing `preprocessor_config.json` due to an interrupted download
- This caused `AutoProcessor.from_pretrained()` to fail at inference time with: `does not appear to have a file named preprocessor_config.json`
- `is_model_downloaded()` only checked for `.safetensors`/`.bin` files, not the processor config required by transformers

## Changes
- **`ocr_catalog.py`**: `is_model_downloaded()` now also checks for `preprocessor_config.json`, so incomplete downloads show as "not downloaded" and can be re-triggered
- **`ocr.py`**: Post-download verification also checks for `preprocessor_config.json` and fails the download if missing, triggering proper cleanup

## Test plan
- [ ] Fresh OCR model download completes with all files including `preprocessor_config.json`
- [ ] If download is interrupted mid-way, model shows as "not downloaded" in the UI
- [ ] OCR on an image/document works after a successful download
- [ ] Deleting and re-downloading the model works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)