### PR TITLE
feat(win): bundle pyannote diarization + embedding model for Windows parity

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           cuda: '12.6.3'
           method: 'network'
-          sub-packages: '["cudart", "cublas", "cufft", "curand", "cusparse", "nvrtc"]'
+          sub-packages: '["cudart", "cublas"]'
 
       # Cache Python standalone + dependencies to speed up builds
       - name: Cache Python environment
@@ -71,7 +71,7 @@ jobs:
         id: python-cache
         with:
           path: build/python-standalone
-          key: ${{ runner.os }}-${{ matrix.arch }}-python-ml-v2-${{ hashFiles('scripts/requirements-core.txt', 'scripts/requirements-ml.txt', 'scripts/requirements-ml-windows.txt', 'scripts/install-bundled-deps.sh') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-python-ml-v4-${{ hashFiles('scripts/requirements-core.txt', 'scripts/requirements-ml.txt', 'scripts/requirements-ml-windows.txt', 'scripts/install-bundled-deps.sh') }}
 
       - name: Install dependencies
         run: pnpm install
@@ -148,17 +148,14 @@ jobs:
           check_installed "python-pptx" || FAILED=1
 
           # ML packages (verify exact versions)
-          if [ "${{ matrix.platform }}" = "win32" ]; then
-            check_version "torch" "2.8.0+cu126" || FAILED=1
-            check_version "torchaudio" "2.8.0+cu126" || FAILED=1
-          else
-            check_version "torch" "2.8.0" || FAILED=1
-            check_version "torchaudio" "2.8.0" || FAILED=1
-          fi
+          check_version "torch" "2.8.0" || FAILED=1
+          check_version "torchaudio" "2.8.0" || FAILED=1
           check_version "huggingface-hub" "0.36.1" || FAILED=1
           check_version "transformers" "4.48.0" || FAILED=1
           check_version "numpy" "2.0.2" || FAILED=1
           check_version "whisperx" "3.3.4" || FAILED=1
+
+          # pyannote — bundled on all platforms
           check_version "pyannote.audio" "3.3.2" || FAILED=1
           check_version "pyannote.core" "5.0.0" || FAILED=1
           check_version "pyannote.database" "5.1.3" || FAILED=1
@@ -228,6 +225,41 @@ jobs:
           du -sh "$WHISPER_DIR"
           ls -la "$SNAPSHOTS_DIR"
 
+      # Cache embedding model to avoid re-downloading every build (~274MB)
+      - name: Cache Embedding model
+        if: matrix.platform == 'win32'
+        uses: actions/cache@v4
+        id: embedding-cache
+        with:
+          path: build/resources/embedding-models
+          key: embedding-models-v1-${{ runner.os }}-${{ hashFiles('scripts/prepare-embedding-model-windows.sh') }}
+
+      - name: Prepare Embedding model for bundling (Windows)
+        if: matrix.platform == 'win32' && steps.embedding-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          echo "Downloading embedding model for semantic search..."
+          ./scripts/prepare-embedding-model-windows.sh
+        env:
+          HF_HUB_DISABLE_PROGRESS_BARS: 1
+
+      - name: Verify Embedding model is present
+        if: matrix.platform == 'win32'
+        shell: bash
+        run: |
+          EMBED_DIR="build/resources/embedding-models/huggingface/hub/models--nomic-ai--nomic-embed-text-v1.5"
+          if [ ! -d "$EMBED_DIR" ]; then
+            echo "ERROR: Embedding model not found at $EMBED_DIR"
+            exit 1
+          fi
+          SNAPSHOTS_DIR="$EMBED_DIR/snapshots"
+          if [ ! -d "$SNAPSHOTS_DIR" ] || [ -z "$(ls -A $SNAPSHOTS_DIR 2>/dev/null)" ]; then
+            echo "ERROR: Embedding model snapshots directory is empty or missing"
+            exit 1
+          fi
+          echo "Embedding model verified:"
+          du -sh "$EMBED_DIR"
+
       # Cache FFmpeg binaries to avoid re-downloading every build (~50MB)
       - name: Cache FFmpeg
         uses: actions/cache@v4
@@ -239,6 +271,11 @@ jobs:
       - name: Prepare Electron resources
         shell: bash
         run: ./scripts/prepare-electron-resources.sh
+
+      - name: Bundle CUDA runtime libraries
+        if: matrix.platform == 'win32'
+        shell: bash
+        run: ./scripts/bundle-cuda-libs.sh
 
       - name: Strip Python environment (reduce bundle size)
         if: matrix.platform == 'win32'
@@ -256,47 +293,42 @@ jobs:
           rm -rf "$SITE_PACKAGES/torchvision-"*.dist-info
 
           # ---------------------------------------------------------------
-          # 2. Remove PyTorch development/build files (~1-2GB)
+          # 2. Remove nvidia-* pip packages
+          #    CUDA DLLs are now in build/resources/cuda/ via bundle-cuda-libs.sh
+          #    No need to keep full nvidia packages in Python env
           # ---------------------------------------------------------------
-          # C++ headers (only needed for torch C++ extensions)
+          rm -rf "$SITE_PACKAGES/nvidia"
+          rm -rf "$SITE_PACKAGES/nvidia_"*.dist-info
+
+          # ---------------------------------------------------------------
+          # 3. Strip speechbrain/lightning bloat from pyannote dependency tree
+          # ---------------------------------------------------------------
+          rm -rf "$SITE_PACKAGES/speechbrain/tests"
+          rm -rf "$SITE_PACKAGES/speechbrain/recipes"
+          rm -rf "$SITE_PACKAGES/speechbrain/templates"
+          rm -rf "$SITE_PACKAGES/speechbrain/benchmarks"
+          rm -rf "$SITE_PACKAGES/lightning/fabric/test_utilities"
+          rm -rf "$SITE_PACKAGES/lightning/pytorch/test_utilities"
+          rm -rf "$SITE_PACKAGES/pytorch_lightning/demos"
+
+          # ---------------------------------------------------------------
+          # 4. Remove PyTorch development/build files
+          # ---------------------------------------------------------------
           rm -rf "$SITE_PACKAGES/torch/include"
-          # CMake configs
           rm -rf "$SITE_PACKAGES/torch/share"
           rm -rf "$SITE_PACKAGES/torch/lib/cmake"
-          # Static import libraries (.lib) - only .dll needed at runtime
           find "$SITE_PACKAGES/torch" -name "*.lib" -delete 2>/dev/null || true
-          # Debug symbols
           find "$SITE_PACKAGES/torch" -name "*.pdb" -delete 2>/dev/null || true
 
           # ---------------------------------------------------------------
-          # 3. Remove PyTorch test *scripts* only (torch/test is standalone
-          #    test runner scripts, NOT importable modules)
+          # 5. Remove PyTorch test scripts only
           # ---------------------------------------------------------------
           rm -rf "$SITE_PACKAGES/torch/test"
-          # NOTE: Do NOT remove any torch Python packages (testing/_internal,
-          # _inductor, onnx, profiler, distributed, utils/benchmark, etc.)
-          # PyTorch 2.8 has deep cross-module imports at init time and
-          # removing ANY of these causes ImportError at runtime.
-
-          # ---------------------------------------------------------------
-          # 4. NVIDIA CUDA libraries — KEEP these!
-          #    nvidia-cudnn, nvidia-cublas, nvidia-nvjitlink etc. are needed
-          #    for GPU inference. PyTorch's torch/lib/ alone is not sufficient.
-          # ---------------------------------------------------------------
-
-          # ---------------------------------------------------------------
-          # 5. Remove unnecessary files from other packages
-          # ---------------------------------------------------------------
-          rm -rf "$SITE_PACKAGES/speechbrain/tests"
-          rm -rf "$SITE_PACKAGES/lightning/fabric/test_utilities"
 
           # ---------------------------------------------------------------
           # 6. General cleanup
           # ---------------------------------------------------------------
-          # __pycache__ directories
           find "$SITE_PACKAGES" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-          # NOTE: Keep .dist-info directories — pip list needs them, and they're
-          # included in the cached Python environment used by subsequent builds
 
           echo "=== After cleanup ==="
           du -sh "$SITE_PACKAGES" || true
@@ -305,21 +337,44 @@ jobs:
           du -sh "$SITE_PACKAGES"/torch 2>/dev/null || true
           du -sh "$SITE_PACKAGES"/torchaudio 2>/dev/null || true
 
-      - name: Verify PyTorch and CUDA after stripping
+      - name: Verify imports after stripping
         if: matrix.platform == 'win32'
         shell: bash
         run: |
           PYTHON_BIN="build/python-standalone/python-windows-x64/python.exe"
           SITE_PACKAGES="build/python-standalone/python-windows-x64/Lib/site-packages"
-          echo "=== Verifying PyTorch imports after strip ==="
+          echo "=== Verifying imports after strip ==="
           "$PYTHON_BIN" -c "
           import torch
           print('PyTorch version:', torch.__version__)
-          print('CUDA available:', torch.cuda.is_available())
           import torchaudio
           print('torchaudio version:', torchaudio.__version__)
+          import ctranslate2
+          print('CTranslate2 version:', ctranslate2.__version__)
+          print('CTranslate2 CUDA devices:', ctranslate2.get_cuda_device_count())
+          import pyannote.audio
+          print('pyannote.audio version:', pyannote.audio.__version__)
+          import speechbrain
+          print('speechbrain version:', speechbrain.__version__)
           print('All imports OK')
           "
+
+      - name: Bundle Size Check
+        if: matrix.platform == 'win32'
+        shell: bash
+        run: |
+          RESOURCES_DIR="build/resources"
+          if [ -d "$RESOURCES_DIR" ]; then
+            SIZE_MB=$(du -sm "$RESOURCES_DIR" | cut -f1)
+            echo "Resources directory size: ${SIZE_MB}MB"
+            if [ "$SIZE_MB" -gt 1800 ]; then
+              echo "::warning::Resources size ${SIZE_MB}MB exceeds 1800MB safety threshold for NSIS 2GB limit"
+            else
+              echo "Resources size ${SIZE_MB}MB is within 1800MB safety threshold"
+            fi
+          else
+            echo "Resources directory not found (may not be assembled yet)"
+          fi
 
       - name: Update version from git tag
         shell: bash
@@ -352,31 +407,6 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
-      - name: Create Windows archive (ultra compression)
-        if: matrix.platform == 'win32'
-        shell: bash
-        run: |
-          VERSION=$(node -p "require('./apps/electron/package.json').version")
-          cd dist/win-unpacked
-          echo "=== Unpacked app size ==="
-          du -sh . || true
-          # Use 7z ultra compression (LZMA2, dict=256MB) to fit under GitHub's 2GB limit
-          7z a -t7z -mx=9 -m0=lzma2 -md=256m -mfb=273 "../Verbatim Studio-${VERSION}-win.7z" .
-          cd ..
-          echo "=== Archive size ==="
-          ls -lh "Verbatim Studio-${VERSION}-win.7z"
-          FILE_SIZE=$(stat -c%s "Verbatim Studio-${VERSION}-win.7z" 2>/dev/null || stat -f%z "Verbatim Studio-${VERSION}-win.7z")
-          echo "Size in bytes: $FILE_SIZE"
-          if [ "$FILE_SIZE" -gt 2147483648 ]; then
-            echo "WARNING: Archive exceeds GitHub's 2GB limit ($FILE_SIZE bytes)"
-            echo "Splitting into volumes..."
-            rm "Verbatim Studio-${VERSION}-win.7z"
-            cd win-unpacked
-            7z a -t7z -mx=9 -m0=lzma2 -md=256m -mfb=273 -v1900m "../Verbatim Studio-${VERSION}-win.7z" .
-            cd ..
-            ls -lh Verbatim\ Studio-${VERSION}-win.7z.*
-          fi
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -384,8 +414,6 @@ jobs:
           path: |
             dist/*.dmg
             dist/*.exe
-            dist/*.7z
-            dist/*.7z.*
           if-no-files-found: error
 
   release:

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -78,6 +78,20 @@
       {
         "from": "../../scripts/requirements-ml-windows.txt",
         "to": "requirements-ml-windows.txt"
+      },
+      {
+        "from": "../../build/resources/cuda",
+        "to": "cuda",
+        "filter": [
+          "**/*"
+        ]
+      },
+      {
+        "from": "../../build/resources/embedding-models",
+        "to": "embedding-models",
+        "filter": [
+          "**/*"
+        ]
       }
     ],
     "mac": {
@@ -100,12 +114,18 @@
       "icon": "assets/icon.png",
       "target": [
         {
-          "target": "dir",
+          "target": "nsis",
           "arch": [
             "x64"
           ]
         }
       ]
+    },
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true,
+      "deleteAppDataOnUninstall": false
     },
     "linux": {
       "icon": "assets/icon.png",

--- a/apps/electron/src/main/backend.ts
+++ b/apps/electron/src/main/backend.ts
@@ -56,10 +56,10 @@ class BackendManager extends EventEmitter {
     // Build PATH based on platform
     let extendedPath: string;
     if (process.platform === 'win32') {
-      // Windows: prepend PyTorch's bundled CUDA DLLs to PATH
-      // PyTorch includes CUDA runtime in its torch/lib/ directory
-      const torchLibPath = path.join(process.resourcesPath, 'python', 'Lib', 'site-packages', 'torch', 'lib');
-      extendedPath = [torchLibPath, process.env.PATH || ''].join(';');
+      // Windows: prepend bundled CUDA DLLs to PATH for CTranslate2 GPU inference.
+      // CTranslate2 dynamically loads cublas, cudart, and cuDNN DLLs from PATH.
+      const cudaPath = path.join(process.resourcesPath, 'cuda');
+      extendedPath = [cudaPath, process.env.PATH || ''].join(';');
     } else {
       // macOS/Linux: add common binary paths (Homebrew, MacPorts, etc.)
       // Electron apps don't inherit the user's shell PATH

--- a/apps/electron/src/main/bootstrap-models.ts
+++ b/apps/electron/src/main/bootstrap-models.ts
@@ -11,7 +11,7 @@ import { existsSync, readdirSync } from 'fs';
 import * as path from 'path';
 
 // Model definitions - which models are bundled and where they go
-// Note: Only whisper-base is bundled. Pyannote models require HF auth and are downloaded on first use.
+// Pyannote/diarization models require HF auth and are downloaded on first use.
 // macOS uses MLX-format models, Windows uses CTranslate2-format models
 const BUNDLED_MODELS = process.platform === 'win32'
   ? [
@@ -19,6 +19,11 @@ const BUNDLED_MODELS = process.platform === 'win32'
         name: 'whisper-base-ct2',
         source: 'whisper-models/huggingface/hub/models--Systran--faster-whisper-base',
         destination: 'huggingface/hub/models--Systran--faster-whisper-base',
+      },
+      {
+        name: 'nomic-embed-text-v1.5',
+        source: 'embedding-models/huggingface/hub/models--nomic-ai--nomic-embed-text-v1.5',
+        destination: 'huggingface/hub/models--nomic-ai--nomic-embed-text-v1.5',
       },
     ]
   : [

--- a/packages/backend/adapters/transcription/whisperx.py
+++ b/packages/backend/adapters/transcription/whisperx.py
@@ -358,14 +358,23 @@ class WhisperXTranscriptionEngine(ITranscriptionEngine):
         }
 
         if available:
+            # CTranslate2 CUDA detection (independent of PyTorch CUDA)
+            try:
+                import ctranslate2
+                cuda_count = ctranslate2.get_cuda_device_count()
+                info["ctranslate2_cuda_devices"] = cuda_count
+                info["cuda_available"] = cuda_count > 0
+            except (ImportError, Exception):
+                info["cuda_available"] = False
+
+            # MPS detection (Apple Silicon)
             try:
                 import torch
-                info["cuda_available"] = torch.cuda.is_available()
-                info["mps_available"] = torch.backends.mps.is_available()
-                if torch.cuda.is_available():
-                    info["cuda_device_name"] = torch.cuda.get_device_name(0)
+                info["mps_available"] = (
+                    hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+                )
             except (ImportError, AttributeError):
-                pass
+                info["mps_available"] = False
 
         return info
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,17 +1,23 @@
 ## What's New in v0.39.1
 
 ### 🐛 Bug Fixes
-- Fixed uploads, recordings, live transcription, and video processing failing on Windows
+- Fixed Windows installer failing to build due to bundle size exceeding NSIS limits
 - Fixed GPU/CUDA not being used for AI transcription on Windows (was falling back to CPU)
+- Fixed uploads, recordings, live transcription, and video processing failing on Windows
 - Fixed "Failed to start backend" error on first launch due to slow initial startup
 - Fixed OCR model dependencies installing an incompatible version on Windows
 - Fixed OCR appearing ready before all required packages were installed
 
 ### 🔧 Improvements
+- Reduced Windows installer size significantly (~3GB smaller) while keeping GPU transcription
+- GPU transcription now works out of the box on Windows with NVIDIA GPUs
+- Windows feature parity with macOS for bundled functionality (transcription, diarization, semantic search, document processing)
+- Speaker diarization libraries now bundled on Windows (models still require HuggingFace token)
+- Semantic search embedding model bundled for offline use
 - Increased backend startup timeout to handle first-launch model loading on Windows
 - Increased frontend connection retry window with smarter backoff for slow startups
-- Added CI verification step to catch broken PyTorch imports after build optimization
 
 ### 📝 Notes
 - GPU acceleration requires an NVIDIA GPU with CUDA support
+- Speaker diarization requires a HuggingFace token and model download on first use
 - First launch may take 30-60 seconds while models are prepared

--- a/scripts/bundle-cuda-libs.sh
+++ b/scripts/bundle-cuda-libs.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -e
+
+# Bundle CUDA runtime DLLs for CTranslate2 GPU inference on Windows.
+#
+# CTranslate2 (used by faster-whisper/WhisperX) has its own CUDA bindings
+# and needs cublas, cudart, and cuDNN DLLs on PATH at runtime.
+#
+# Sources:
+#   - cublas + cudart: CUDA Toolkit (installed by Jimver/cuda-toolkit CI action)
+#   - cuDNN 9: nvidia-cudnn-cu12 pip package
+#
+# Output: build/resources/cuda/ (included as extraResource in Electron app)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUTPUT_DIR="$PROJECT_ROOT/build/resources/cuda"
+
+# Python binary for pip operations
+PYTHON_DIR="$PROJECT_ROOT/build/python-standalone/python-windows-x64"
+PYTHON_BIN="$PYTHON_DIR/python.exe"
+SITE_PACKAGES="$PYTHON_DIR/Lib/site-packages"
+
+echo "=== Bundling CUDA Runtime Libraries for CTranslate2 ==="
+
+mkdir -p "$OUTPUT_DIR"
+
+# ---------------------------------------------------------------
+# 1. Copy cuBLAS + cudart from CUDA Toolkit
+# ---------------------------------------------------------------
+if [ -n "$CUDA_PATH" ]; then
+  CUDA_DIR="$CUDA_PATH"
+elif [ -d "/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA" ]; then
+  CUDA_DIR=$(ls -d "/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v"* 2>/dev/null | sort -V | tail -1)
+elif [ -d "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA" ]; then
+  CUDA_DIR=$(ls -d "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v"* 2>/dev/null | sort -V | tail -1)
+else
+  echo "ERROR: CUDA Toolkit not found. Set CUDA_PATH or install CUDA Toolkit."
+  exit 1
+fi
+
+echo "CUDA Toolkit: $CUDA_DIR"
+
+CUDA_BIN="$CUDA_DIR/bin"
+TOOLKIT_PATTERNS=(
+  "cublas64_*.dll"
+  "cublasLt64_*.dll"
+  "cudart64_*.dll"
+)
+
+COPIED=0
+for pattern in "${TOOLKIT_PATTERNS[@]}"; do
+  for dll in "$CUDA_BIN"/$pattern; do
+    if [ -f "$dll" ]; then
+      cp "$dll" "$OUTPUT_DIR/"
+      echo "  Copied (toolkit): $(basename "$dll")"
+      COPIED=$((COPIED + 1))
+    fi
+  done
+done
+
+echo "Copied $COPIED DLLs from CUDA Toolkit"
+
+# ---------------------------------------------------------------
+# 2. Install nvidia-cudnn-cu12 and copy cuDNN DLLs
+#    CTranslate2 4.5+ requires cuDNN 9 for Whisper model inference
+# ---------------------------------------------------------------
+echo ""
+echo "=== Installing nvidia-cudnn-cu12 for cuDNN DLLs ==="
+
+"$PYTHON_BIN" -m pip install \
+  --target "$SITE_PACKAGES" \
+  nvidia-cudnn-cu12 \
+  --quiet
+
+# cuDNN DLLs are in site-packages/nvidia/cudnn/bin/
+CUDNN_BIN="$SITE_PACKAGES/nvidia/cudnn/bin"
+if [ -d "$CUDNN_BIN" ]; then
+  CUDNN_COUNT=0
+  for dll in "$CUDNN_BIN"/*.dll; do
+    if [ -f "$dll" ]; then
+      cp "$dll" "$OUTPUT_DIR/"
+      echo "  Copied (cuDNN): $(basename "$dll")"
+      CUDNN_COUNT=$((CUDNN_COUNT + 1))
+    fi
+  done
+  echo "Copied $CUDNN_COUNT cuDNN DLLs"
+else
+  # Try alternative path
+  CUDNN_LIB="$SITE_PACKAGES/nvidia/cudnn/lib"
+  if [ -d "$CUDNN_LIB" ]; then
+    CUDNN_COUNT=0
+    for dll in "$CUDNN_LIB"/*.dll; do
+      if [ -f "$dll" ]; then
+        cp "$dll" "$OUTPUT_DIR/"
+        echo "  Copied (cuDNN): $(basename "$dll")"
+        CUDNN_COUNT=$((CUDNN_COUNT + 1))
+      fi
+    done
+    echo "Copied $CUDNN_COUNT cuDNN DLLs"
+  else
+    echo "WARNING: cuDNN DLLs not found at $CUDNN_BIN or $CUDNN_LIB"
+    echo "CTranslate2 GPU inference may fail without cuDNN."
+  fi
+fi
+
+# ---------------------------------------------------------------
+# 3. Clean up nvidia pip packages from site-packages
+#    DLLs are now in build/resources/cuda/ — no need to keep
+#    the full nvidia packages in the Python environment.
+# ---------------------------------------------------------------
+echo ""
+echo "=== Cleaning nvidia pip packages from site-packages ==="
+rm -rf "$SITE_PACKAGES/nvidia"
+rm -rf "$SITE_PACKAGES/nvidia_"*.dist-info
+echo "Removed nvidia packages from site-packages"
+
+echo ""
+echo "=== CUDA DLL Bundle Summary ==="
+du -sh "$OUTPUT_DIR" || true
+ls -la "$OUTPUT_DIR"
+echo ""
+echo "Done. CUDA DLLs staged at: $OUTPUT_DIR"

--- a/scripts/prepare-electron-resources.sh
+++ b/scripts/prepare-electron-resources.sh
@@ -65,6 +65,13 @@ if [ -d "$RESOURCES_DIR/cuda" ]; then
   PRESERVED_ITEMS+=("cuda")
 fi
 
+# Preserve embedding-models if they exist
+if [ -d "$RESOURCES_DIR/embedding-models" ]; then
+  echo "Preserving embedding-models directory..."
+  mv "$RESOURCES_DIR/embedding-models" "$TEMP_PRESERVE/"
+  PRESERVED_ITEMS+=("embedding-models")
+fi
+
 rm -rf "$RESOURCES_DIR"
 mkdir -p "$RESOURCES_DIR"
 

--- a/scripts/prepare-embedding-model-windows.sh
+++ b/scripts/prepare-embedding-model-windows.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e
+
+# Prepare sentence-transformer embedding model for bundling with Windows Electron app.
+# Downloads nomic-ai/nomic-embed-text-v1.5 from HuggingFace.
+#
+# Usage: ./scripts/prepare-embedding-model-windows.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUTPUT_DIR="$PROJECT_ROOT/build/resources/embedding-models"
+
+echo "=== Preparing Embedding Model for Windows Bundling ==="
+echo "Output directory: $OUTPUT_DIR"
+
+# Find the Python binary - prefer bundled Python if available
+PYTHON_DIR="$PROJECT_ROOT/build/python-standalone/python-windows-x64"
+if [ -f "$PYTHON_DIR/python.exe" ]; then
+    PYTHON_BIN="$PYTHON_DIR/python.exe"
+    SITE_PACKAGES="$PYTHON_DIR/Lib/site-packages"
+    export PYTHONPATH="$SITE_PACKAGES:$PYTHONPATH"
+    echo "Using bundled Python: $PYTHON_BIN"
+else
+    PYTHON_BIN="python3"
+    echo "Using system Python: $PYTHON_BIN"
+    "$PYTHON_BIN" -c "import huggingface_hub" 2>/dev/null || {
+        echo "Installing huggingface_hub..."
+        "$PYTHON_BIN" -m pip install --quiet huggingface_hub
+    }
+fi
+
+# Create output directories
+mkdir -p "$OUTPUT_DIR/huggingface/hub"
+
+# Download nomic-embed-text-v1.5 (public model, no auth required)
+REPO="nomic-ai/nomic-embed-text-v1.5"
+DEST_NAME="models--nomic-ai--nomic-embed-text-v1.5"
+DEST_DIR="$OUTPUT_DIR/huggingface/hub/$DEST_NAME"
+
+echo ""
+echo "--- Downloading $REPO ---"
+
+if [ -d "$DEST_DIR" ] && [ "$(ls -A "$DEST_DIR" 2>/dev/null)" ]; then
+    echo "Model already exists at $DEST_DIR, skipping..."
+else
+    SNAPSHOT_DIR="$DEST_DIR/snapshots/main"
+    mkdir -p "$SNAPSHOT_DIR"
+
+    # Convert Git Bash path to Windows path for native Python
+    if command -v cygpath &>/dev/null; then
+        WIN_SNAPSHOT_DIR=$(cygpath -w "$SNAPSHOT_DIR")
+    else
+        WIN_SNAPSHOT_DIR="$SNAPSHOT_DIR"
+    fi
+
+    "$PYTHON_BIN" -c "
+import os, sys
+from huggingface_hub import snapshot_download
+
+repo_id = '$REPO'
+local_dir = r'$WIN_SNAPSHOT_DIR'
+
+print(f'Downloading {repo_id} to {local_dir}...')
+snapshot_download(
+    repo_id=repo_id,
+    local_dir=local_dir,
+)
+print(f'Downloaded to: {local_dir}')
+
+# Verify key model files exist
+for expected in ['config.json', 'tokenizer.json']:
+    fpath = os.path.join(local_dir, expected)
+    if os.path.exists(fpath):
+        size_kb = os.path.getsize(fpath) / 1024
+        print(f'Verified: {expected} ({size_kb:.1f} KB)')
+    else:
+        print(f'WARNING: {expected} not found in {local_dir}')
+
+# Report total size
+total = sum(
+    os.path.getsize(os.path.join(dp, f))
+    for dp, _, fnames in os.walk(local_dir)
+    for f in fnames
+)
+print(f'Total model size: {total / (1024*1024):.1f} MB')
+"
+
+    echo "Download complete."
+fi
+
+echo ""
+echo "=== Embedding Model Preparation Complete ==="
+echo "Model prepared in: $OUTPUT_DIR"
+ls -la "$DEST_DIR/snapshots/" 2>/dev/null || echo "(could not list snapshots)"

--- a/scripts/requirements-core.txt
+++ b/scripts/requirements-core.txt
@@ -2,6 +2,9 @@
 # ML dependencies are downloaded on first use (not bundled)
 # Use >= constraints to match pyproject.toml
 
+# Required by ctranslate2 and other packages that use pkg_resources
+setuptools>=75.0.0
+
 # Web framework
 fastapi>=0.115.0
 uvicorn[standard]>=0.34.0

--- a/scripts/requirements-ml-windows.txt
+++ b/scripts/requirements-ml-windows.txt
@@ -1,14 +1,16 @@
-# ML dependencies for Windows x64 + CUDA
+# ML dependencies for Windows x64
 # Fork of requirements-ml.txt:
 # - Removes mlx-whisper (Apple Silicon only)
-# - Sources PyTorch from CUDA 12.6 index
-# Install with: --extra-index-url https://download.pytorch.org/whl/cu126
+# - Uses CPU-only PyTorch (GPU transcription via CTranslate2's native CUDA)
+# - Bundles pyannote for diarization (same as macOS)
 
 # =============================================================================
-# PyTorch ecosystem - CUDA 12.6
+# PyTorch ecosystem - CPU only
+# GPU transcription uses CTranslate2's own CUDA bindings, not PyTorch CUDA.
+# CUDA runtime DLLs (cublas, cudnn, cudart) are bundled as extraResources.
 # =============================================================================
-torch==2.8.0+cu126
-torchaudio==2.8.0+cu126
+torch==2.8.0
+torchaudio==2.8.0
 # torchvision excluded from bundle to reduce size (~1GB)
 # OCR feature installs it on-demand when user downloads OCR models
 
@@ -24,7 +26,7 @@ transformers==4.48.0
 whisperx==3.3.4
 
 # =============================================================================
-# Speaker diarization
+# Speaker diarization (library only — models downloaded post-install)
 # =============================================================================
 pyannote.audio==3.3.2
 pyannote-core==5.0.0

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -22,6 +22,16 @@ fi
 NUMERIC_VERSION="${VERSION#v}"
 NUMERIC_VERSION="${NUMERIC_VERSION%+*}"
 
+# If version isn't valid semver (e.g. bare commit SHA on PR builds),
+# fall back to the version already in package.json
+if ! [[ "$NUMERIC_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    ELECTRON_PKG="$REPO_ROOT/apps/electron/package.json"
+    FALLBACK=$(grep -o '"version": *"[^"]*"' "$ELECTRON_PKG" | head -1 | sed 's/"version": *"//;s/"//')
+    echo "WARNING: '$NUMERIC_VERSION' is not valid semver, falling back to package.json version: $FALLBACK"
+    NUMERIC_VERSION="$FALLBACK"
+    VERSION="v$FALLBACK"
+fi
+
 # Update frontend version.ts
 VERSION_FILE="$REPO_ROOT/packages/frontend/src/version.ts"
 cat > "$VERSION_FILE" << EOF


### PR DESCRIPTION
## Summary
- Bundles pyannote.audio + speechbrain + pytorch-lightning libraries on Windows (diarization was completely broken — import errors)
- Bundles nomic-ai/nomic-embed-text-v1.5 embedding model so semantic search works offline with no post-install downloads
- Switches Windows from CUDA PyTorch (~3GB) to CPU PyTorch + CTranslate2 native CUDA (~1GB), bundling only the CUDA DLLs CTranslate2 needs
- Uses CTranslate2 for CUDA detection throughout the backend (PyTorch is CPU-only, so `torch.cuda.is_available()` would always return false)

## Files changed

| Area | Files | What |
|------|-------|------|
| **Requirements** | `requirements-ml-windows.txt` | Added 5 pyannote packages |
| **CI** | `build-electron.yml` | Pyannote verification unconditional, embedding model cache/download/verify, bundle size guard, cache key v4 |
| **Scripts** | `install-bundled-deps.sh` | Removed Windows exemption from pyannote checks |
| **Scripts** | `prepare-embedding-model-windows.sh` | **New** — downloads embedding model at build time |
| **Scripts** | `bundle-cuda-libs.sh` | **New** — extracts CUDA DLLs from toolkit + cuDNN pip pkg |
| **Scripts** | `prepare-electron-resources.sh` | Preserves embedding-models dir |
| **Electron** | `package.json` | Added embedding-models + cuda extraResources, NSIS config |
| **Electron** | `bootstrap-models.ts` | Copies embedding model to HF cache on first launch |
| **Electron** | `backend.ts` | PATH points to `cuda/` for CTranslate2 DLLs |
| **Backend** | `transcription_settings.py` | CTranslate2 CUDA detection (4 functions) |
| **Backend** | `whisperx.py` | CTranslate2 CUDA detection in engine info |
| **Backend** | `system.py` | CTranslate2 CUDA detection in memory/GPU reporting |

## Test plan
- [ ] CI "Verify Python dependencies" passes pyannote version checks on Windows
- [ ] CI "Verify imports after stripping" imports pyannote.audio + speechbrain
- [ ] CI "Verify Embedding model" finds nomic-embed-text-v1.5 in build resources
- [ ] CI "Bundle Size Check" reports resources under 1800MB
- [ ] NSIS installer builds successfully (under 2GB)
- [ ] macOS build unaffected (no changes to macOS-specific paths)