### PR TITLE
feat(electron): add splash screen with startup progress

### DIFF
--- a/apps/electron/src/main/backend.ts
+++ b/apps/electron/src/main/backend.ts
@@ -222,7 +222,7 @@ class BackendManager extends EventEmitter {
     }
   }
 
-  private async waitForHealth(timeout = 60000): Promise<void> {
+  private async waitForHealth(timeout = 120000): Promise<void> {
     const startTime = Date.now();
     const url = `http://127.0.0.1:${this._port}/health`;
 

--- a/apps/electron/src/main/splash.ts
+++ b/apps/electron/src/main/splash.ts
@@ -1,0 +1,90 @@
+import { BrowserWindow } from 'electron';
+
+let splashWindow: BrowserWindow | null = null;
+
+const SPLASH_HTML = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  -webkit-app-region: drag;
+  user-select: none;
+  overflow: hidden;
+}
+.title {
+  font-size: 21px;
+  font-weight: 600;
+  color: #f8fafc;
+  letter-spacing: -0.01em;
+  margin-bottom: 28px;
+}
+.spinner {
+  width: 26px;
+  height: 26px;
+  border: 2.5px solid rgba(255,255,255,0.06);
+  border-top-color: #4B8FDE;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+  margin-bottom: 18px;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+#status {
+  font-size: 12px;
+  color: #64748b;
+  text-align: center;
+  max-width: 320px;
+  line-height: 1.4;
+}
+</style></head><body>
+  <div class="title">Verbatim Studio</div>
+  <div class="spinner"></div>
+  <div id="status">Initializing\u2026</div>
+</body></html>`;
+
+export function createSplashWindow(): BrowserWindow {
+  splashWindow = new BrowserWindow({
+    width: 400,
+    height: 220,
+    frame: false,
+    resizable: false,
+    center: true,
+    skipTaskbar: false,
+    backgroundColor: '#0f172a',
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+  });
+
+  splashWindow.loadURL(
+    `data:text/html;charset=utf-8,${encodeURIComponent(SPLASH_HTML)}`
+  );
+
+  splashWindow.once('ready-to-show', () => {
+    splashWindow?.show();
+  });
+
+  return splashWindow;
+}
+
+export function updateSplashStatus(text: string): void {
+  if (!splashWindow || splashWindow.isDestroyed()) return;
+  const safe = text.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  splashWindow.webContents
+    .executeJavaScript(`document.getElementById('status').textContent='${safe}';`)
+    .catch(() => {});
+}
+
+export function closeSplashWindow(): void {
+  if (!splashWindow || splashWindow.isDestroyed()) return;
+  splashWindow.close();
+  splashWindow = null;
+}


### PR DESCRIPTION
## Summary
- Adds a branded splash window that appears instantly on launch, replacing the blank ~50s wait while the Python backend loads on Windows
- Splash shows progressive status messages parsed from backend logs: *Checking models → Starting backend → Loading AI libraries → Loading audio models → Starting server → Loading interface*
- Increases backend health-check timeout from 60s to 120s to prevent false "startup failed" errors on slower machines

## Test plan
- [ ] Launch the installed app on Windows — splash should appear immediately
- [ ] Verify status text updates as the backend loads
- [ ] Splash should close and main window should appear once backend is ready
- [ ] On error, splash should close before the error dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)