### PR TITLE
feat: Windows full GPU acceleration via Settings > AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ Each AI feature loads its own model. You only pay for what you use — deactivat
 
 > **Tip:** On a 16 GB machine you can comfortably run transcription + diarization + search + Max simultaneously. OCR is loaded on-demand and released when idle.
 
+### Windows GPU / VRAM
+
+Out of the box, only transcription uses your NVIDIA GPU (via CTranslate2). To accelerate **all** AI features on the GPU, open **Settings > AI** and click **Enable Full GPU Acceleration** (~2.8 GB download).
+
+| Feature | VRAM | Notes |
+|---------|------|-------|
+| Transcription (Whisper base) | ~200 MB | GPU by default (CTranslate2) |
+| Transcription (Whisper large-v3) | ~3 GB | GPU by default (CTranslate2) |
+| Speaker ID (pyannote) | ~1 GB | Requires GPU acceleration pack |
+| Semantic search (nomic-embed) | ~600 MB | Requires GPU acceleration pack |
+| AI Assistant (Granite 8B) | ~5 GB | Requires GPU acceleration pack |
+| OCR (Qwen2-VL 2B) | ~5 GB | Requires GPU acceleration pack |
+
+> **Minimum VRAM:** 4 GB handles transcription + diarization + search. **Recommended:** 8 GB+ for the full AI suite including Granite and OCR.
+>
+> No NVIDIA GPU? Everything works on CPU — just slower for transcription.
+
 ---
 
 ## Features

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -9,6 +9,11 @@ export function registerIpcHandlers(): void {
     return app.getVersion();
   });
 
+  ipcMain.handle('app:restart', () => {
+    app.relaunch();
+    app.exit(0);
+  });
+
   // API URL - returns the backend URL for the renderer
   ipcMain.handle('api:getUrl', () => {
     return backendManager.getApiUrl();

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -11,6 +11,7 @@ try {
 
   // App info
   getAppVersion: (): Promise<string> => ipcRenderer.invoke('app:getVersion'),
+  restartApp: (): Promise<void> => ipcRenderer.invoke('app:restart'),
 
   // API connection
   getApiUrl: (): Promise<string | null> => ipcRenderer.invoke('api:getUrl'),
@@ -100,6 +101,7 @@ declare global {
     electronAPI?: {
       platform: NodeJS.Platform;
       getAppVersion: () => Promise<string>;
+      restartApp: () => Promise<void>;
       getApiUrl: () => Promise<string | null>;
       getApiPort: () => Promise<number | null>;
       getConnectionMode: () => Promise<'local' | 'connected' | 'hybrid'>;

--- a/packages/frontend/src/pages/settings/SettingsPage.tsx
+++ b/packages/frontend/src/pages/settings/SettingsPage.tsx
@@ -415,6 +415,8 @@ export function SettingsPage({ theme, onThemeChange }: SettingsPageProps) {
           }
         } else if (event.status === 'error') {
           setGpuError(event.message);
+          setGpuInstalling(false);
+          break;
         }
       }
     } catch (err) {

--- a/packages/frontend/src/types/electron.d.ts
+++ b/packages/frontend/src/types/electron.d.ts
@@ -6,6 +6,7 @@
 interface ElectronAPI {
   platform: NodeJS.Platform;
   getAppVersion: () => Promise<string>;
+  restartApp: () => Promise<void>;
   getApiUrl: () => Promise<string | null>;
   getApiPort: () => Promise<number | null>;
   getConnectionMode: () => Promise<'local' | 'connected' | 'hybrid'>;


### PR DESCRIPTION
## Summary
- Adds a **GPU Acceleration** card to **Settings > AI** (Windows only) that lets users enable full GPU acceleration for all AI features with one click
- Backend `GET /system/gpu-status` endpoint reports per-feature GPU/CPU status (transcription, speaker ID, semantic search, AI assistant, OCR)
- Backend `POST /system/enable-gpu` endpoint installs CUDA PyTorch + CUDA llama-cpp-python via SSE-streamed pip, with disk space pre-flight check and setuptools<72 pin to protect ctranslate2
- Frontend shows GPU name, feature status table, upgrade button with download size estimate, progress bar, and auto-restarts the app on completion
- Adds `restartApp` Electron IPC for post-install restart
- Documents Windows VRAM requirements in README

**Context:** Out of the box, only transcription uses the GPU (via CTranslate2's native CUDA). All other models (pyannote, embeddings, OCR, Granite 8B) have GPU-aware code but fall back to CPU because PyTorch is bundled as CPU-only. This feature lets users download CUDA PyTorch (~2.8 GB) to unlock GPU for everything.

## Test plan
- [ ] On Windows with NVIDIA GPU: Settings > AI shows GPU Acceleration card with "Partial" badge and feature table
- [ ] Click "Enable Full GPU Acceleration" — progress bar streams status, app restarts on completion
- [ ] After restart, card shows "Full GPU" badge and all features report GPU
- [ ] On Windows without NVIDIA GPU: card shows "No NVIDIA GPU detected"
- [ ] On macOS: GPU Acceleration card does not appear
- [ ] `GET /api/system/gpu-status` returns correct feature status on all platforms
- [ ] `POST /api/system/enable-gpu` returns "Windows only" error on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)