### PR TITLE
fix: cancel recording UI update and live transcription disconnect error

### DIFF
--- a/packages/backend/api/routes/recordings.py
+++ b/packages/backend/api/routes/recordings.py
@@ -1200,13 +1200,10 @@ async def cancel_recording(
             detail="Could not cancel the job",
         )
 
-    # For queued jobs, cancellation is immediate — update recording status now
-    if was_queued:
-        recording.status = "cancelled"
-        await db.commit()
-        await broadcast("recordings", "status_changed", recording_id)
-
-    # For running jobs, the cooperative cancellation in _run_job will update recording status
+    # Update recording status immediately so the UI responds right away
+    recording.status = "cancelled"
+    await db.commit()
+    await broadcast("recordings", "status_changed", recording_id)
 
     logger.info("Cancellation requested for recording %s (job %s)", recording_id, job.id)
     return MessageResponse(message="Cancellation requested", id=recording_id)

--- a/packages/backend/services/jobs.py
+++ b/packages/backend/services/jobs.py
@@ -541,13 +541,23 @@ async def handle_transcription(
                 )
                 session.add(speaker)
 
-            # Update recording status to completed
+            # Update recording status to completed (only if still processing — cancel may have set it to cancelled)
             await session.execute(
-                update(Recording).where(Recording.id == recording_id).values(status="completed")
+                update(Recording)
+                .where(Recording.id == recording_id, Recording.status == "processing")
+                .values(status="completed")
             )
             await session.commit()
 
+            # Check if the recording was cancelled while we were working
+            rec_result = await session.execute(select(Recording.status).where(Recording.id == recording_id))
+            rec_status = rec_result.scalar_one_or_none()
+
             transcript_id = transcript.id
+
+        if rec_status == "cancelled":
+            logger.info("Recording %s was cancelled during transcription, discarding result", recording_id)
+            return {"transcript_id": transcript_id, "cancelled": True}
 
         # Broadcast status change so frontend updates immediately
         await broadcast("recordings", "status_changed", recording_id)
@@ -603,10 +613,12 @@ async def handle_transcription(
         raise
 
     except Exception as e:
-        # Update recording status to failed
+        # Update recording status to failed (only if still processing — cancel may have set it to cancelled)
         async with get_session_factory()() as session:
             await session.execute(
-                update(Recording).where(Recording.id == recording_id).values(status="failed")
+                update(Recording)
+                .where(Recording.id == recording_id, Recording.status == "processing")
+                .values(status="failed")
             )
             await session.commit()
         # Broadcast status change so frontend updates immediately

--- a/packages/frontend/src/components/recordings/AudioRecorder.tsx
+++ b/packages/frontend/src/components/recordings/AudioRecorder.tsx
@@ -21,6 +21,7 @@ export function AudioRecorder({ onRecordingComplete, onCancel, audioBitsPerSecon
   const timerRef = useRef<number | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const animationRef = useRef<number | null>(null);
+  const cancelledRef = useRef(false);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -57,6 +58,7 @@ export function AudioRecorder({ onRecordingComplete, onCancel, audioBitsPerSecon
   const startRecording = async () => {
     try {
       setError(null);
+      cancelledRef.current = false;
       chunksRef.current = [];
 
       // Request microphone access
@@ -98,6 +100,10 @@ export function AudioRecorder({ onRecordingComplete, onCancel, audioBitsPerSecon
       };
 
       mediaRecorder.onstop = () => {
+        if (cancelledRef.current) {
+          cancelledRef.current = false;
+          return;
+        }
         // Create blob from chunks
         const blob = new Blob(chunksRef.current, { type: mimeType });
         const extension = mimeType.includes('webm') ? 'webm' : 'm4a';
@@ -171,8 +177,12 @@ export function AudioRecorder({ onRecordingComplete, onCancel, audioBitsPerSecon
   };
 
   const cancelRecording = () => {
+    cancelledRef.current = true;
     if (timerRef.current) clearInterval(timerRef.current);
     if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+      mediaRecorderRef.current.stop();
+    }
     if (streamRef.current) {
       streamRef.current.getTracks().forEach(track => track.stop());
     }

--- a/packages/frontend/src/hooks/useLiveTranscription.ts
+++ b/packages/frontend/src/hooks/useLiveTranscription.ts
@@ -85,6 +85,7 @@ export function useLiveTranscription(): UseLiveTranscriptionReturn {
   const isRecordingRef = useRef(false);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef<number | null>(null);
+  const userDisconnectedRef = useRef(false);
   const sessionIdRef = useRef<string | null>(null);
 
   // Keep ref in sync for use in callbacks
@@ -228,7 +229,10 @@ export function useLiveTranscription(): UseLiveTranscriptionReturn {
     };
 
     ws.onclose = () => {
-      if (isRecordingRef.current && reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+      if (userDisconnectedRef.current) {
+        userDisconnectedRef.current = false;
+        setConnectionState('disconnected');
+      } else if (isRecordingRef.current && reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
         const delay = Math.min(
           BASE_RECONNECT_DELAY_MS * Math.pow(2, reconnectAttemptsRef.current),
           30_000
@@ -252,6 +256,7 @@ export function useLiveTranscription(): UseLiveTranscriptionReturn {
 
   const connect = useCallback(async () => {
     setError(null);
+    userDisconnectedRef.current = false;
     setConnectionState('connecting');
 
     try {
@@ -281,6 +286,7 @@ export function useLiveTranscription(): UseLiveTranscriptionReturn {
   }, [createWebSocket]);
 
   const disconnect = useCallback(() => {
+    userDisconnectedRef.current = true;
     reconnectAttemptsRef.current = MAX_RECONNECT_ATTEMPTS;
     cleanup(true);
     setConnectionState('disconnected');


### PR DESCRIPTION
## Summary
- **Cancel recording not updating UI**: Backend cancel endpoint now immediately sets recording status to "cancelled" and broadcasts, giving instant UI feedback. Transcription handler guards against overwriting cancelled status back to completed/failed.
- **Audio recorder cancel not stopping upload**: MediaRecorder is now explicitly stopped on cancel with a ref flag preventing the onstop handler from uploading the cancelled recording.
- **Live transcription showing "Connection lost" on user disconnect**: Added a `userDisconnectedRef` flag so the WebSocket onclose handler skips the error message when disconnect was user-initiated.

## Test plan
- [ ] Start a transcription, click Cancel — UI should immediately show "cancelled" status
- [ ] Start recording audio, click Cancel — recording should stop without uploading
- [ ] Connect to live transcription, then disconnect — should not show "Connection lost" error
- [ ] Disconnect live transcription via network loss — should still show "Connection lost" after retries exhausted

🤖 Generated with [Claude Code](https://claude.com/claude-code)