### PR TITLE
Move workflows to self-hosted runners

### DIFF
--- a/.github/workflows/sync-release-notes.yml
+++ b/.github/workflows/sync-release-notes.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   sync-notes:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, jongodb]
     steps:
       - name: Sync release notes to public releases repo
         env:


### PR DESCRIPTION
Phase 2 of the migration off GitHub-hosted runners.

Switches `runs-on: ubuntu-latest` → `runs-on: [self-hosted, jongodb]` in the listed files. Mac/Windows-touching workflows are intentionally skipped.

Files changed: .github/workflows/sync-release-notes.yml

Pilot (kestrel#25) merged and Release+CI jobs validated on the self-hosted pool.

## Test plan
- [ ] After merge, watch the next workflow run pick up on `jongodb-labs-runner-N`.
- [ ] If a step fails with "command not found", add the appropriate `actions/setup-*` step (the self-hosted image has Docker + Ubuntu base, not the full GitHub-hosted toolchain).