### PR TITLE
Move workflows to self-hosted runners

### DIFF
--- a/.github/workflows/build-vocab-corpus.yml
+++ b/.github/workflows/build-vocab-corpus.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   build:
     name: Assemble corpus
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, jongodb]
     # Embedding 339K terms via Nomic on a CPU-only ubuntu-latest runner
     # takes 60-150 min depending on runner load. 90 was too tight (saw
     # 91-min timeouts cancel both v0.64.2 and v0.64.3 corpus builds).


### PR DESCRIPTION
Auto-opened by gh-runners-audit. Migrates Linux-only workflow files to the self-hosted runner pool. Skipped any file that references macos/windows.

Files changed: build-vocab-corpus.yml

This PR is created automatically; review and merge at your convenience.